### PR TITLE
[AA-1612] - Versioning cleanup

### DIFF
--- a/.github/workflows/on-merge-or-tag.yml
+++ b/.github/workflows/on-merge-or-tag.yml
@@ -51,9 +51,10 @@ jobs:
         if: "! startsWith(github.ref_name, 'AdminApp.Web-v')"
         run: |
           $version = "${{ steps.versions.outputs.admin-api }}"
+          $tag = $version -replace "-v","-Pre-Release-v"
 
           $body = @{
-            tag_name = "Pre-Release-$version"
+            tag_name = "$tag"
             target_commitish = "main"
             name = $version
             body = ""

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -32,7 +32,7 @@ jobs:
 
           # example: "AdminApp.Web-v2.5.1"
           # output: "AdminApp.Web"
-          $packageName = ($release -split "-v")[0]
+          $packageName = ($release -split "-")[0]
 
           $page = 1
           $release_list = @()
@@ -48,7 +48,7 @@ jobs:
             $release_list = Invoke-RestMethod $url -Headers $gh_headers
 
             $release_list | ForEach-Object {
-                if ($_.tag_name -like "$(-join('Pre-Release-',$packageName))-*" -and $_.prerelease) {
+                if ($_.tag_name -like "$($packageName)-Pre-Release-*" -and $_.prerelease) {
                     "Deleting pre-release $($_.tag_name)" | Write-Output
                     Invoke-RestMethod -Method Delete -Uri $_.url -Headers $gh_headers
                 }

--- a/Application/EdFi.Ods.Admin.Api/EdFi.Ods.Admin.Api.csproj
+++ b/Application/EdFi.Ods.Admin.Api/EdFi.Ods.Admin.Api.csproj
@@ -6,7 +6,6 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <IsPackable>true</IsPackable>
     <NoWarn>NU5100, NU5124</NoWarn>
-    <MinVerTagPrefix>Admin.Api-v</MinVerTagPrefix>
   </PropertyGroup>
 
   <ItemGroup>
@@ -26,10 +25,6 @@
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="3.1.1" />
     <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.3" />
     <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.3.1" />
-    <PackageReference Include="MinVer" Version="4.2.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
+++ b/Application/EdFi.Ods.AdminApp.Web/EdFi.Ods.AdminApp.Web.csproj
@@ -3,7 +3,6 @@
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>
     <IsPackable>true</IsPackable>
-    <MinVerTagPrefix>AdminApp.Web-v</MinVerTagPrefix>
   </PropertyGroup>
 
   <ItemGroup>
@@ -39,10 +38,6 @@
     <PackageReference Include="HtmlTags" Version="8.1.1" />
     <PackageReference Include="LigerShark.WebOptimizer.Core" Version="3.0.357" />
     <PackageReference Include="log4net" Version="2.0.13" />
-    <PackageReference Include="MinVer" Version="4.2.0">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
     <PackageReference Include="Npgsql" Version="6.0.3" />
     <PackageReference Include="Microsoft.Extensions.Logging.Log4Net.AspNetCore" Version="6.1.0" />
   </ItemGroup>


### PR DESCRIPTION
**Description**
- Removed MinVer MSBuild integration from csproj files which are overriding the passed-in version to `build.ps1`
- Renamed GH Release Tags (called pre-releases) by adding "-Pre-Release-" before the version instead of before the package name. Refactored on-release.yml accordingly.

**Corresponding [Admin App PR](https://github.com/Ed-Fi-Alliance-OSS/Ed-Fi-ODS-AdminApp/pull/359)**