### PR TITLE
Quick fix for environment variable context-loss issue)

### DIFF
--- a/.github/workflows/on-prerelease.yml
+++ b/.github/workflows/on-prerelease.yml
@@ -205,7 +205,7 @@ jobs:
     uses: Ed-Fi-Alliance-OSS/slsa-github-generator/.github/workflows/generator_generic_slsa3.yml@v1.2.0
     with:
       base64-subjects: ${{ needs.pack.outputs.hash-code }}
-      attestation-name: "${{ env.PACKAGE_NAME }}.intoto.jsonl"
+      attestation-name: Admin.Api.intoto.jsonl
       upload-assets: true
       # TODO: remove this after this issue is resolved: https://github.com/slsa-framework/slsa-github-generator/issues/876
       compile-generator: true


### PR DESCRIPTION
As the `provenance-create` job uses a reusable workflow file and there are [limitations ](https://docs.github.com/en/enterprise-cloud@latest/actions/using-workflows/reusing-workflows#limitations)on the env variable usage for such cases, we are going with directly using the value for `attestation-name`