### PR TITLE
[ADMINAPI-54] Remove EdFi.Security References from Admin API

### DIFF
--- a/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/AddClaimSet.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/AddClaimSet.cs
@@ -102,7 +102,7 @@ namespace EdFi.Ods.Admin.Api.Features.ClaimSets
 
             private bool BeAUniqueName(string? name)
             {
-                return _getAllClaimSetsQuery.Execute().All(x => x.ClaimSetName != name);
+                return _getAllClaimSetsQuery.Execute().All(x => x.Name != name);
             }
         }
     }

--- a/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/AddClaimSet.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/AddClaimSet.cs
@@ -27,8 +27,8 @@ namespace EdFi.Ods.Admin.Api.Features.ClaimSets
             IGetClaimSetByIdQuery getClaimSetByIdQuery,
             IGetResourcesByClaimSetIdQuery getResourcesByClaimSetIdQuery,
             IGetApplicationsByClaimSetIdQuery getApplications,
+            IAuthStrategyResolver strategyResolver,
             IMapper mapper,
-            ISecurityContext securityContext,
             Request request)
         {
             await validator.GuardAsync(request);
@@ -37,8 +37,10 @@ namespace EdFi.Ods.Admin.Api.Features.ClaimSets
                 ClaimSetName = request.Name
             });
 
-            request.ResourceClaims?.ResolveAuthStrategies(securityContext);
-            addOrEditResourcesOnClaimSetCommand.Execute(addedClaimSetId, mapper.Map<List<ResourceClaim>>(request.ResourceClaims));
+            var resourceClaims = mapper.Map<List<ResourceClaim>>(request.ResourceClaims);
+            var resolvedResourceClaims = strategyResolver.ResolveAuthStrategies(resourceClaims).ToList();
+
+            addOrEditResourcesOnClaimSetCommand.Execute(addedClaimSetId, resolvedResourceClaims);
 
             var claimSet = getClaimSetByIdQuery.Execute(addedClaimSetId);
             var allResources = getResourcesByClaimSetIdQuery.AllResources(addedClaimSetId);

--- a/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/AddClaimSet.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/AddClaimSet.cs
@@ -66,13 +66,13 @@ namespace EdFi.Ods.Admin.Api.Features.ClaimSets
             private GetAllClaimSetsQuery _getAllClaimSetsQuery;
 
             public Validator(GetAllClaimSetsQuery getAllClaimSetsQuery,
-                GetResourceClaimsQuery getResourceClaimsQuery,
+                GetResourceClaimsAsFlatListQuery getResourceClaimsAsFlatListQuery,
                 GetAllAuthorizationStrategiesQuery getAllAuthorizationStrategiesQuery)
             {
                 _getAllClaimSetsQuery = getAllClaimSetsQuery;
 
-                var resourceClaims = getResourceClaimsQuery.Execute()
-                    .ToDictionary(rc => rc.Name.ToLower());
+                var resourceClaims = (Lookup<string, ResourceClaim>)getResourceClaimsAsFlatListQuery.Execute()
+                    .ToLookup(rc => rc.Name.ToLower());
 
                 var authStrategyNames = getAllAuthorizationStrategiesQuery.Execute()
                     .Select(a => a.AuthStrategyName).ToList();

--- a/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/ClaimSetModel.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/ClaimSetModel.cs
@@ -4,7 +4,6 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
-using EdFi.Security.DataAccess.Contexts;
 using Swashbuckle.AspNetCore.Annotations;
 using EdFi.Ods.Admin.Api.Infrastructure.Documentation;
 
@@ -90,45 +89,5 @@ namespace EdFi.Ods.Admin.Api.Features.ClaimSets
         public string? Name { get; set; }
 
         public int Id { get; set; }
-    }
-
-    public static class ResourceClaimsModelExtensions
-    {
-        public static void ResolveAuthStrategies(this List<ResourceClaimModel> resourceClaims, ISecurityContext securityContext)
-        {
-            var dbAuthStrategies = securityContext.AuthorizationStrategies;
-
-            foreach (var claim in resourceClaims)
-            {
-                if (claim.DefaultAuthStrategiesForCRUD != null && claim.DefaultAuthStrategiesForCRUD.Any())
-                {
-                    foreach (var defaultAS in claim.DefaultAuthStrategiesForCRUD.Where(x => x != null))
-                    {
-                        var authStrategy = dbAuthStrategies.SingleOrDefault(x => x.AuthorizationStrategyName.Equals(defaultAS.AuthStrategyName, StringComparison.InvariantCultureIgnoreCase));
-                        if (authStrategy != null)
-                        {
-                            defaultAS.AuthStrategyId = authStrategy.AuthorizationStrategyId;
-                            defaultAS.DisplayName = authStrategy.DisplayName;
-                        }
-                    }
-                }
-                if (claim.AuthStrategyOverridesForCRUD != null && claim.AuthStrategyOverridesForCRUD.Any())
-                {
-                    foreach (var authStrategyOverride in claim.AuthStrategyOverridesForCRUD.Where(x => x != null))
-                    {
-                        var authStrategy = dbAuthStrategies.SingleOrDefault(x => x.AuthorizationStrategyName.Equals(authStrategyOverride.AuthStrategyName, StringComparison.InvariantCultureIgnoreCase));
-                        if (authStrategy != null)
-                        {
-                            authStrategyOverride.AuthStrategyId = authStrategy.AuthorizationStrategyId;
-                            authStrategyOverride.DisplayName = authStrategy.DisplayName;
-                        }
-                    }
-                }
-                if (claim.Children != null && claim.Children.Any())
-                {
-                    ResolveAuthStrategies(claim.Children, securityContext);
-                }
-            }
-        }
     }
 }

--- a/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/ClaimSetModel.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/ClaimSetModel.cs
@@ -36,7 +36,7 @@ namespace EdFi.Ods.Admin.Api.Features.ClaimSets
         public AuthorizationStrategyModel[]? AuthStrategyOverridesForCRUD { get; set; }
 
         [SwaggerSchema(Description = "Children are collection of ResourceClaim")]
-        public List<ResourceClaimModel>? Children { get; set; }
+        public List<ResourceClaimModel> Children { get; set; }
         public ResourceClaimModel()
         {
             Children = new List<ResourceClaimModel>();

--- a/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/DeleteClaimSet.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/DeleteClaimSet.cs
@@ -22,7 +22,7 @@ namespace EdFi.Ods.Admin.Api.Features.ClaimSets
                 .BuildForVersions(AdminApiVersions.V1);
         }
 
-        public Task<IResult> Handle(DeleteClaimSetCommand deleteClaimSetCommand, [FromServices]GetClaimSetByIdQuery getClaimSetByIdQuery, IGetApplicationsByClaimSetIdQuery getApplications, int id)
+        public Task<IResult> Handle(DeleteClaimSetCommand deleteClaimSetCommand, [FromServices]IGetClaimSetByIdQuery getClaimSetByIdQuery, IGetApplicationsByClaimSetIdQuery getApplications, int id)
         {
             CheckClaimSetExists(id, getClaimSetByIdQuery);
             CheckAgainstDeletingClaimSetsWithApplications(id, getApplications);
@@ -39,7 +39,7 @@ namespace EdFi.Ods.Admin.Api.Features.ClaimSets
             return Task.FromResult(AdminApiResponse.Deleted("ClaimSet"));
         }
 
-        private void CheckClaimSetExists(int id, GetClaimSetByIdQuery query)
+        private void CheckClaimSetExists(int id, IGetClaimSetByIdQuery query)
         {
             try
             {

--- a/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/DeleteClaimSet.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/DeleteClaimSet.cs
@@ -8,6 +8,7 @@ using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using EdFi.Ods.AdminApp.Management.ErrorHandling;
 using FluentValidation;
 using FluentValidation.Results;
+using Microsoft.AspNetCore.Mvc;
 
 namespace EdFi.Ods.Admin.Api.Features.ClaimSets
 {
@@ -21,7 +22,7 @@ namespace EdFi.Ods.Admin.Api.Features.ClaimSets
                 .BuildForVersions(AdminApiVersions.V1);
         }
 
-        public Task<IResult> Handle(DeleteClaimSetCommand deleteClaimSetCommand, GetClaimSetByIdQuery getClaimSetByIdQuery, IGetApplicationsByClaimSetIdQuery getApplications, int id)
+        public Task<IResult> Handle(DeleteClaimSetCommand deleteClaimSetCommand, [FromServices]GetClaimSetByIdQuery getClaimSetByIdQuery, IGetApplicationsByClaimSetIdQuery getApplications, int id)
         {
             CheckClaimSetExists(id, getClaimSetByIdQuery);
             CheckAgainstDeletingClaimSetsWithApplications(id, getApplications);

--- a/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/EditClaimSet.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/EditClaimSet.cs
@@ -87,14 +87,14 @@ namespace EdFi.Ods.Admin.Api.Features.ClaimSets
 
             public Validator(IGetClaimSetByIdQuery getClaimSetByIdQuery,
                 GetAllClaimSetsQuery getAllClaimSetsQuery,
-                GetResourceClaimsQuery getResourceClaimsQuery,
+                GetResourceClaimsAsFlatListQuery getResourceClaimsAsFlatListQuery,
                 GetAllAuthorizationStrategiesQuery getAllAuthorizationStrategiesQuery)
             {
                 _getClaimSetByIdQuery = getClaimSetByIdQuery;
                 _getAllClaimSetsQuery = getAllClaimSetsQuery;
 
-                var resourceClaims = getResourceClaimsQuery.Execute()
-                    .ToDictionary(rc => rc.Name.ToLower());
+                var resourceClaims = (Lookup<string, ResourceClaim>)getResourceClaimsAsFlatListQuery.Execute()
+                    .ToLookup(rc => rc.Name.ToLower());
 
                 var authStrategyNames = getAllAuthorizationStrategiesQuery.Execute()
                     .Select(a => a.AuthStrategyName).ToList();

--- a/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/EditClaimSet.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/EditClaimSet.cs
@@ -150,7 +150,7 @@ namespace EdFi.Ods.Admin.Api.Features.ClaimSets
 
             private bool BeAUniqueName(string? name)
             {
-                return _getAllClaimSetsQuery.Execute().All(x => x.ClaimSetName != name);
+                return _getAllClaimSetsQuery.Execute().All(x => x.Name != name);
             }
         }
     }

--- a/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/ReadClaimSets.cs
+++ b/Application/EdFi.Ods.Admin.Api/Features/ClaimSets/ReadClaimSets.cs
@@ -30,7 +30,7 @@ public class ReadClaimSets : IFeature
 
     internal Task<IResult> GetClaimSets(GetAllClaimSetsQuery getClaimSetsQuery, IGetApplicationsByClaimSetIdQuery getApplications, IMapper mapper)
     {
-        var claimSets = getClaimSetsQuery.Execute().Where(x => !CloudOdsAdminApp.SystemReservedClaimSets.Contains(x.ClaimSetName)).ToList();
+        var claimSets = getClaimSetsQuery.Execute().Where(x => !CloudOdsAdminApp.SystemReservedClaimSets.Contains(x.Name)).ToList();
         var model = mapper.Map<List<ClaimSetModel>>(claimSets);
         foreach(var claimSet in model)
         {

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AutoMapper/AdminApiMappingProfile.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AutoMapper/AdminApiMappingProfile.cs
@@ -9,6 +9,7 @@ using EdFi.Ods.Admin.Api.Features.Vendors;
 using EdFi.Ods.Admin.Api.Features.Applications;
 using EdFi.Ods.AdminApp.Management.Database.Commands;
 using EdFi.Ods.Admin.Api.Features.ClaimSets;
+using EdFi.Security.DataAccess.Models;
 
 namespace EdFi.Ods.Admin.Api.Infrastructure
 {
@@ -47,6 +48,10 @@ namespace EdFi.Ods.Admin.Api.Infrastructure
                 .ForMember(dst => dst.Id, opt => opt.MapFrom(src => src.Id))
                 .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.Name))
                 .ForMember(dst => dst.IsSystemReserved, opt => opt.MapFrom(src => !src.IsEditable));
+
+            CreateMap<ClaimSet, ClaimSetModel>()
+                .ForMember(dst => dst.Id, opt => opt.MapFrom(src => src.ClaimSetId))
+                .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.ClaimSetName));
 
             CreateMap<AdminApp.Management.ClaimSetEditor.ResourceClaim, ResourceClaimModel>()
                 .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.Name))

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AutoMapper/AdminApiMappingProfile.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AutoMapper/AdminApiMappingProfile.cs
@@ -8,7 +8,6 @@ using Profile = AutoMapper.Profile;
 using EdFi.Ods.Admin.Api.Features.Vendors;
 using EdFi.Ods.Admin.Api.Features.Applications;
 using EdFi.Ods.AdminApp.Management.Database.Commands;
-using EdFi.Security.DataAccess.Models;
 using EdFi.Ods.Admin.Api.Features.ClaimSets;
 
 namespace EdFi.Ods.Admin.Api.Infrastructure
@@ -44,20 +43,10 @@ namespace EdFi.Ods.Admin.Api.Infrastructure
                 .ForMember(dst => dst.Key, opt => opt.MapFrom(src => src.Key))
                 .ForMember(dst => dst.Secret, opt => opt.MapFrom(src => src.Secret));
 
-
-            CreateMap<AuthorizationStrategy, AdminApp.Management.ClaimSetEditor.AuthorizationStrategy>()
-                .ForMember(dst => dst.AuthStrategyName, opt => opt.MapFrom(src => src.AuthorizationStrategyName))
-                .ForMember(dst => dst.AuthStrategyId, opt => opt.MapFrom(src => src.AuthorizationStrategyId))
-                .ForMember(dst => dst.IsInheritedFromParent, opt => opt.Ignore());
-
             CreateMap<AdminApp.Management.ClaimSetEditor.ClaimSet, ClaimSetDetailsModel>()
                 .ForMember(dst => dst.Id, opt => opt.MapFrom(src => src.Id))
                 .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.Name))
                 .ForMember(dst => dst.IsSystemReserved, opt => opt.MapFrom(src => !src.IsEditable));
-
-            CreateMap<ClaimSet, ClaimSetModel>()
-                .ForMember(dst => dst.Id, opt => opt.MapFrom(src => src.ClaimSetId))
-                .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.ClaimSetName));
 
             CreateMap<AdminApp.Management.ClaimSetEditor.ResourceClaim, ResourceClaimModel>()
                 .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.Name))
@@ -90,8 +79,6 @@ namespace EdFi.Ods.Admin.Api.Infrastructure
                 .ForMember(dst => dst.AuthStrategyOverridesForCRUD, opt => opt.MapFrom(src => src.AuthStrategyOverridesForCRUD))
                 .ForMember(dst => dst.DefaultAuthStrategiesForCRUD, opt => opt.MapFrom(src => src.DefaultAuthStrategiesForCRUD))
                 .ForMember(dst => dst.Children, opt => opt.MapFrom(src => src.Children));
-
-
         }
 
         private string ToCommaSeparated(ICollection<VendorNamespacePrefix> vendorNamespacePrefixes)

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/AutoMapper/AdminApiMappingProfile.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/AutoMapper/AdminApiMappingProfile.cs
@@ -9,7 +9,6 @@ using EdFi.Ods.Admin.Api.Features.Vendors;
 using EdFi.Ods.Admin.Api.Features.Applications;
 using EdFi.Ods.AdminApp.Management.Database.Commands;
 using EdFi.Ods.Admin.Api.Features.ClaimSets;
-using EdFi.Security.DataAccess.Models;
 
 namespace EdFi.Ods.Admin.Api.Infrastructure
 {
@@ -49,9 +48,9 @@ namespace EdFi.Ods.Admin.Api.Infrastructure
                 .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.Name))
                 .ForMember(dst => dst.IsSystemReserved, opt => opt.MapFrom(src => !src.IsEditable));
 
-            CreateMap<ClaimSet, ClaimSetModel>()
-                .ForMember(dst => dst.Id, opt => opt.MapFrom(src => src.ClaimSetId))
-                .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.ClaimSetName));
+            CreateMap<AdminApp.Management.ClaimSetEditor.ClaimSet, ClaimSetModel>()
+                .ForMember(dst => dst.Id, opt => opt.MapFrom(src => src.Id))
+                .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.Name));
 
             CreateMap<AdminApp.Management.ClaimSetEditor.ResourceClaim, ResourceClaimModel>()
                 .ForMember(dst => dst.Name, opt => opt.MapFrom(src => src.Name))

--- a/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
+++ b/Application/EdFi.Ods.Admin.Api/Infrastructure/WebApplicationBuilderExtensions.cs
@@ -10,6 +10,7 @@ using EdFi.Ods.Admin.Api.Infrastructure.Documentation;
 using EdFi.Ods.Admin.Api.Infrastructure.Security;
 using EdFi.Ods.AdminApp.Management;
 using EdFi.Ods.AdminApp.Management.Api;
+using EdFi.Ods.AdminApp.Management.Api.Automapper;
 using EdFi.Ods.AdminApp.Management.Database;
 using EdFi.Security.DataAccess.Contexts;
 using FluentValidation.AspNetCore;
@@ -24,7 +25,7 @@ public static class WebApplicationBuilderExtensions
     public static void AddServices(this WebApplicationBuilder webApplicationBuilder)
     {
         var executingAssembly = Assembly.GetExecutingAssembly();
-        webApplicationBuilder.Services.AddAutoMapper(executingAssembly);
+        webApplicationBuilder.Services.AddAutoMapper(executingAssembly, typeof(AdminManagementMappingProfile).Assembly);
         webApplicationBuilder.Services.AddScoped<InstanceContext>();
 
         foreach (var type in typeof(IMarkerForEdFiOdsAdminAppManagement).Assembly.GetTypes())

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetAllAuthorizationStrategiesQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetAllAuthorizationStrategiesQueryTests.cs
@@ -1,0 +1,33 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Linq;
+using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
+using NUnit.Framework;
+using Shouldly;
+using Application = EdFi.Security.DataAccess.Models.Application;
+
+namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor;
+
+[TestFixture]
+public class GetAllAuthorizationStrategiesQueryTests : SecurityDataTestBase
+{
+    [Test]
+    public void ShouldGetAllAuthorizationStrategies()
+    {
+        LoadSeedData();
+
+        Transaction(securityContext =>
+        {
+            var query = new GetAllAuthorizationStrategiesQuery(securityContext);
+            var resultNames = query.Execute().Select(x => x.AuthStrategyName).ToList();
+
+            resultNames.Count.ShouldBeGreaterThan(2);
+
+            resultNames.ShouldContain("NamespaceBased");
+            resultNames.ShouldContain("NoFurtherAuthorizationRequired");
+        });
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetAllAuthorizationStrategiesQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/GetAllAuthorizationStrategiesQueryTests.cs
@@ -24,7 +24,7 @@ public class GetAllAuthorizationStrategiesQueryTests : SecurityDataTestBase
             var query = new GetAllAuthorizationStrategiesQuery(securityContext);
             var resultNames = query.Execute().Select(x => x.AuthStrategyName).ToList();
 
-            resultNames.Count.ShouldBeGreaterThan(2);
+            resultNames.Count.ShouldBe(2);
 
             resultNames.ShouldContain("NamespaceBased");
             resultNames.ShouldContain("NoFurtherAuthorizationRequired");

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetAllClaimSetsQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetAllClaimSetsQueryTests.cs
@@ -38,7 +38,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Queries
             var claimSetNames = Scoped<ISecurityContext, string[]>(securityContext =>
             {
                 var query = new GetAllClaimSetsQuery(securityContext);
-                return query.Execute().Select(x => x.ClaimSetName).ToArray();
+                return query.Execute().Select(x => x.Name).ToArray();
             });
 
             claimSetNames.ShouldContain(claimSet1.ClaimSetName);

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetChildResourceClaimsForParentQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetChildResourceClaimsForParentQueryTests.cs
@@ -52,6 +52,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Queries
                 results.All(x => x.Update == false).ShouldBe(true);
                 results.All(x => x.Read == false).ShouldBe(true);
                 results.All(x => x.ParentId.Equals(testParentResource.ResourceClaimId)).ShouldBe(true);
+                results.All(x => x.ParentName.Equals(testParentResource.ResourceName)).ShouldBe(true);
             });
         }
     }

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetResourceClaimsAsFlatListQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetResourceClaimsAsFlatListQueryTests.cs
@@ -1,0 +1,133 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using EdFi.Ods.AdminApp.Management.Database.Queries;
+using EdFi.Security.DataAccess.Contexts;
+using NUnit.Framework;
+using Shouldly;
+using Application = EdFi.Security.DataAccess.Models.Application;
+using ResourceClaim = EdFi.Security.DataAccess.Models.ResourceClaim;
+using static EdFi.Ods.AdminApp.Management.Tests.Testing;
+
+namespace EdFi.Ods.AdminApp.Management.Tests.Database.Queries
+{
+    [TestFixture]
+    public class GetResourceClaimsAsFlatListQueryTests : SecurityDataTestBase
+    {
+        [Test]
+        public void ShouldGetResourceClaimsAsFlatList()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = "TestApplicationName"
+            };
+
+            Save(testApplication);
+
+            var testResourceClaims = SetupResourceClaims(testApplication);
+
+            Management.ClaimSetEditor.ResourceClaim[] results = null;
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var query = new GetResourceClaimsAsFlatListQuery(securityContext);
+
+                results = query.Execute().ToArray();
+            });
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                results.Length.ShouldBe(testResourceClaims.Count);
+                results.Select(x => x.Name).ShouldBe(testResourceClaims.Select(x => x.ResourceName), true);
+                results.Select(x => x.Id).ShouldBe(testResourceClaims.Select(x => x.ResourceClaimId), true);
+                results.All(x => x.Create == false).ShouldBe(true);
+                results.All(x => x.Delete == false).ShouldBe(true);
+                results.All(x => x.Update == false).ShouldBe(true);
+                results.All(x => x.Read == false).ShouldBe(true);
+                results.All(x => x.ParentId.Equals(0)).ShouldBe(true);
+                results.All(x => x.ParentName == null).ShouldBe(true);
+                results.All(x => x.Children.Count == 0).ShouldBe(true);
+            });
+        }
+
+        [Test]
+        public void ShouldGetAlphabeticallySortedFlatListForResourceClaims()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = "TestApplicationName"
+            };
+
+            Save(testApplication);
+
+            var testResourceClaims = SetupParentResourceClaimsWithChildren(testApplication).ToList();
+            var parentResourceNames = testResourceClaims.Where(x => x.ParentResourceClaim == null)
+                .OrderBy(x => x.ResourceName).Select(x => x.ResourceName).ToList();
+            var childResourceNames = testResourceClaims.Where(x => x.ParentResourceClaim != null)
+                .OrderBy(x => x.ResourceName).Select(x => x.ResourceName).ToList();
+
+            List<Management.ClaimSetEditor.ResourceClaim> results = null;
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var query = new GetResourceClaimsAsFlatListQuery(securityContext);
+
+                results = query.Execute().ToList();
+            });
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                results.Count.ShouldBe(testResourceClaims.Count);
+                results.Where(x => x.ParentId == 0).Select(x => x.Name).ToList().ShouldBe(parentResourceNames);
+                results.Where(x => x.ParentId != 0).Select(x => x.Name).ToList().ShouldBe(childResourceNames);
+            });
+        }
+
+        private IReadOnlyCollection<ResourceClaim> SetupResourceClaims(Application testApplication, int resourceClaimCount = 5)
+        {
+            var resourceClaims = new List<ResourceClaim>();
+            foreach (var index in Enumerable.Range(1, resourceClaimCount))
+            {
+                var resourceClaim = new ResourceClaim
+                {
+                    ClaimName = $"TestResourceClaim{index:N}",
+                    DisplayName = $"TestResourceClaim{index:N}",
+                    ResourceName = $"TestResourceClaim{index:N}",
+                    Application = testApplication
+                };
+                resourceClaims.Add(resourceClaim);
+            }
+
+            Save(resourceClaims.Cast<object>().ToArray());
+
+            return resourceClaims;
+        }
+
+        private IReadOnlyCollection<ResourceClaim> SetupParentResourceClaimsWithChildren(Application testApplication, int resourceClaimCount = 5, int childResourceClaimCount = 3)
+        {
+            var parentResourceClaims = Enumerable.Range(1, resourceClaimCount).Select(parentIndex => new ResourceClaim
+            {
+                ClaimName = $"TestParentResourceClaim{parentIndex}",
+                DisplayName = $"TestParentResourceClaim{parentIndex}",
+                ResourceName = $"TestParentResourceClaim{parentIndex}",
+                Application = testApplication
+            }).ToList();
+
+            var childResourceClaims = parentResourceClaims.SelectMany(x => Enumerable.Range(1, childResourceClaimCount)
+                .Select(childIndex => new ResourceClaim
+                {
+                    ClaimName = $"TestChildResourceClaim{childIndex}",
+                    DisplayName = $"TestChildResourceClaim{childIndex}",
+                    ResourceName = $"TestChildResourceClaim{childIndex}",
+                    Application = testApplication,
+                    ParentResourceClaim = x
+                })).ToList();
+
+            Save(childResourceClaims.Cast<object>().ToArray());
+            parentResourceClaims.AddRange(childResourceClaims);
+            return parentResourceClaims;
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetResourceClaimsQueryTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/Database/Queries/GetResourceClaimsQueryTests.cs
@@ -50,6 +50,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.Database.Queries
                 results.All(x => x.Update == false).ShouldBe(true);
                 results.All(x => x.Read == false).ShouldBe(true);
                 results.All(x => x.ParentId.Equals(0)).ShouldBe(true);
+                results.All(x => x.ParentName == null).ShouldBe(true);
                 results.All(x => x.Children.Count == 0).ShouldBe(true);
             });
         }

--- a/Application/EdFi.Ods.AdminApp.Management/Api/Automapper/AdminManagementMappingProfile.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Api/Automapper/AdminManagementMappingProfile.cs
@@ -10,6 +10,7 @@ using LocalEducationAgency = EdFi.Ods.AdminApp.Management.Api.Models.LocalEducat
 using School = EdFi.Ods.AdminApp.Management.Api.Models.School;
 using EdFi.Ods.AdminApp.Management.Api.DomainModels;
 using EdFi.Ods.AdminApp.Management.Api.Models;
+using EdFi.Security.DataAccess.Models;
 
 namespace EdFi.Ods.AdminApp.Management.Api.Automapper
 {
@@ -161,6 +162,11 @@ namespace EdFi.Ods.AdminApp.Management.Api.Automapper
                 .ForCtorParam("postSecondaryInstitutionLevelDescriptor", opt => opt.MapFrom(src => src.PostSecondaryInstitutionLevel))
                 .ForCtorParam("administrativeFundingControlDescriptor", opt => opt.MapFrom(src => src.AdministrativeFundingControl))
                 .ForCtorParam("nameOfInstitution", opt => opt.MapFrom(src => src.Name));
+
+            CreateMap<AuthorizationStrategy, ClaimSetEditor.AuthorizationStrategy>()
+                .ForMember(dst => dst.AuthStrategyName, opt => opt.MapFrom(src => src.AuthorizationStrategyName))
+                .ForMember(dst => dst.AuthStrategyId, opt => opt.MapFrom(src => src.AuthorizationStrategyId))
+                .ForMember(dst => dst.IsInheritedFromParent, opt => opt.Ignore());
 
             List<EdFiEducationOrganizationAddress> AddressResolver(EducationOrganization source,
                 ResolutionContext context)

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/AuthStrategyResolver.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/AuthStrategyResolver.cs
@@ -1,0 +1,74 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using EdFi.Security.DataAccess.Contexts;
+
+namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor;
+
+public interface IAuthStrategyResolver
+{
+    IEnumerable<ResourceClaim> ResolveAuthStrategies(IEnumerable<ResourceClaim> resourceClaims);
+}
+
+public class AuthStrategyResolver : IAuthStrategyResolver
+{
+    private readonly ISecurityContext _securityContext;
+
+    public AuthStrategyResolver(ISecurityContext securityContext)
+    {
+        _securityContext = securityContext;
+    }
+
+    public IEnumerable<ResourceClaim> ResolveAuthStrategies(IEnumerable<ResourceClaim> resourceClaims)
+    {
+        var dbAuthStrategies = _securityContext.AuthorizationStrategies;
+
+        foreach (var claim in resourceClaims)
+        {
+            if (claim.DefaultAuthStrategiesForCRUD != null && claim.DefaultAuthStrategiesForCRUD.Any())
+            {
+                foreach (var defaultStrategy in claim.DefaultAuthStrategiesForCRUD.Where(x => x != null))
+                {
+                    var authStrategy = dbAuthStrategies.SingleOrDefault(
+                        x => x.AuthorizationStrategyName.Equals(
+                            defaultStrategy.AuthStrategyName, StringComparison.InvariantCultureIgnoreCase));
+
+                    if (authStrategy != null)
+                    {
+                        defaultStrategy.AuthStrategyId = authStrategy.AuthorizationStrategyId;
+                        defaultStrategy.DisplayName = authStrategy.DisplayName;
+                    }
+                }
+            }
+
+            if (claim.AuthStrategyOverridesForCRUD != null && claim.AuthStrategyOverridesForCRUD.Any())
+            {
+                foreach (var authStrategyOverride in claim.AuthStrategyOverridesForCRUD.Where(x => x != null))
+                {
+                    var authStrategy = dbAuthStrategies.SingleOrDefault(
+                        x => x.AuthorizationStrategyName.Equals(
+                            authStrategyOverride.AuthStrategyName,
+                            StringComparison.InvariantCultureIgnoreCase));
+
+                    if (authStrategy != null)
+                    {
+                        authStrategyOverride.AuthStrategyId = authStrategy.AuthorizationStrategyId;
+                        authStrategyOverride.DisplayName = authStrategy.DisplayName;
+                    }
+                }
+            }
+
+            if (claim.Children?.Any() ?? false)
+            {
+                claim.Children = ResolveAuthStrategies(claim.Children).ToList();
+            }
+
+            yield return claim;
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetAllAuthorizationStrategiesQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetAllAuthorizationStrategiesQuery.cs
@@ -1,0 +1,31 @@
+﻿// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using EdFi.Security.DataAccess.Contexts;
+
+namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor;
+
+public class GetAllAuthorizationStrategiesQuery
+{
+    private ISecurityContext _securityContext;
+
+    public GetAllAuthorizationStrategiesQuery(ISecurityContext securityContext)
+    {
+        _securityContext = securityContext;
+    }
+
+    public List<AuthorizationStrategy> Execute()
+    {
+        return _securityContext.AuthorizationStrategies
+            .OrderBy(x => x.AuthorizationStrategyName)
+            .Select(x => new AuthorizationStrategy
+            {
+                AuthStrategyId = x.AuthorizationStrategyId,
+                AuthStrategyName = x.DisplayName
+            }).ToList();
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetAllAuthorizationStrategiesQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/GetAllAuthorizationStrategiesQuery.cs
@@ -25,7 +25,8 @@ public class GetAllAuthorizationStrategiesQuery
             .Select(x => new AuthorizationStrategy
             {
                 AuthStrategyId = x.AuthorizationStrategyId,
-                AuthStrategyName = x.DisplayName
+                AuthStrategyName = x.AuthorizationStrategyName,
+                DisplayName = x.DisplayName
             }).ToList();
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ResourceClaim.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/ResourceClaim.cs
@@ -12,6 +12,7 @@ namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
     {
         public int Id { get; set; }
         public int ParentId { get; set; }
+        public string ParentName { get; set; }
         public string Name { get; set; }
         public bool Read { get; set; }
         public bool Create { get; set; }

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Queries/GetAllClaimSetsQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Queries/GetAllClaimSetsQuery.cs
@@ -6,7 +6,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using EdFi.Security.DataAccess.Contexts;
-using EdFi.Security.DataAccess.Models;
+using ClaimSet = EdFi.Ods.AdminApp.Management.ClaimSetEditor.ClaimSet;
 
 namespace EdFi.Ods.AdminApp.Management.Database.Queries
 {
@@ -22,9 +22,14 @@ namespace EdFi.Ods.AdminApp.Management.Database.Queries
         public IEnumerable<ClaimSet> Execute()
         {
             return _securityContext.ClaimSets
+                .Select(x => new ClaimSet
+                {
+                    Id = x.ClaimSetId,
+                    Name = x.ClaimSetName
+                })
                 .Distinct()
-                .OrderBy(x => x.ClaimSetName)
+                .OrderBy(x => x.Name)
                 .ToList();
-        } 
+        }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Queries/GetChildResourceClaimsForParentQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Queries/GetChildResourceClaimsForParentQuery.cs
@@ -21,6 +21,9 @@ namespace EdFi.Ods.AdminApp.Management.Database.Queries
 
         public IEnumerable<ResourceClaim> Execute(int parentResourceClaimId)
         {
+            var parentResourceClaim = _securityContext.ResourceClaims.SingleOrDefault(
+                    rc => rc.ResourceClaimId == parentResourceClaimId);
+
             var childResourcesForParent = _securityContext.ResourceClaims
                 .Where(x => x.ParentResourceClaimId == parentResourceClaimId).ToList();
             return childResourcesForParent
@@ -28,11 +31,12 @@ namespace EdFi.Ods.AdminApp.Management.Database.Queries
                 {
                     Name = x.ResourceName,
                     Id = x.ResourceClaimId,
-                    ParentId = parentResourceClaimId
+                    ParentId = parentResourceClaimId,
+                    ParentName = parentResourceClaim?.ResourceName,
                 })
                 .Distinct()
                 .OrderBy(x => x.Name)
                 .ToList();
-        } 
+        }
     }
 }

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Queries/GetResourceClaimsAsFlatListQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Queries/GetResourceClaimsAsFlatListQuery.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using System.Linq;
+using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
+using EdFi.Security.DataAccess.Contexts;
+
+namespace EdFi.Ods.AdminApp.Management.Database.Queries
+{
+    public class GetResourceClaimsAsFlatListQuery
+    {
+        private readonly ISecurityContext _securityContext;
+
+        public GetResourceClaimsAsFlatListQuery(ISecurityContext securityContext)
+        {
+            _securityContext = securityContext;
+        }
+
+        public IEnumerable<ResourceClaim> Execute()
+        {
+            return _securityContext.ResourceClaims
+                .Select(x => new ResourceClaim
+                {
+                    Id = x.ResourceClaimId,
+                    Name = x.ResourceName,
+                    ParentId = x.ParentResourceClaimId ?? 0,
+                    ParentName = x.ParentResourceClaim.ResourceName
+                })
+                .Distinct()
+                .OrderBy(x => x.Name)
+                .ToList();
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management/Database/Queries/GetResourceClaimsQuery.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/Database/Queries/GetResourceClaimsQuery.cs
@@ -33,7 +33,8 @@ namespace EdFi.Ods.AdminApp.Management.Database.Queries
                     {
                         Id = child.ResourceClaimId,
                         Name = child.ResourceName,
-                        ParentId = parentResource.ResourceClaimId
+                        ParentId = parentResource.ResourceClaimId,
+                        ParentName = parentResource.ResourceName,
                     }).ToList(),
                     Name = parentResource.ResourceName,
                     Id = parentResource.ResourceClaimId

--- a/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Controllers/ApplicationController.cs
@@ -264,7 +264,7 @@ namespace EdFi.Ods.AdminApp.Web.Controllers
 
         private List<string> GetClaimSetNames()
         {
-            return _getClaimSetNamesQuery.Execute().Select(x => x.ClaimSetName).Except(CloudOdsAdminApp.SystemReservedClaimSets).ToList();
+            return _getClaimSetNamesQuery.Execute().Select(x => x.Name).Except(CloudOdsAdminApp.SystemReservedClaimSets).ToList();
         }
 
         private static string GetApiUrlForDisplay(string apiUrl)

--- a/Application/EdFi.Ods.AdminApp.Web/Infrastructure/AutoMapper/AdminWebMappingProfile.cs
+++ b/Application/EdFi.Ods.AdminApp.Web/Infrastructure/AutoMapper/AdminWebMappingProfile.cs
@@ -115,11 +115,6 @@ namespace EdFi.Ods.AdminApp.Web.Infrastructure.AutoMapper
 
             CreateMap<Descriptor, DescriptorModel>();
 
-            CreateMap<AuthorizationStrategy, Management.ClaimSetEditor.AuthorizationStrategy>()
-                .ForMember(dst => dst.AuthStrategyName, opt => opt.MapFrom(src => src.AuthorizationStrategyName))
-                .ForMember(dst => dst.AuthStrategyId, opt => opt.MapFrom(src => src.AuthorizationStrategyId))
-                .ForMember(dst => dst.IsInheritedFromParent, opt => opt.Ignore());
-
             CreateMap<AdminAppUser, UserModel>()
                 .ForMember(dst => dst.UserId, opt => opt.MapFrom(src => src.Id));
         }


### PR DESCRIPTION
Removes `EdFi.Security.*` references from Admin API, with the exception of database registration.

Re-establishing the boundary between Admin.Api, AdminApp.Management, and the EdFi libraries will ease our work in referencing either version of `EdFi.Security` conditionally.

- replaces assorted `ISecurityContext` calls with comparable queries from `EdFi.Ods.AdminApp.Management` library
- introduces new library queries when they did not exist
- changes DB entities used to comprable `Model`s
- some changes mean more is done in-memory rather than on the database, but given the possible quantity of calls (especially during validation) this may be a performance _improvement_