### PR TITLE
[ADMINAPI-60] Multiversion Support for EditResourceOnClaimSetCommand, UpdateResourcesOnClaimSetCommand, and DeleteResourceOnClaimSetCommand

### DIFF
--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/DeleteResourceOnClaimSetCommandV53ServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/DeleteResourceOnClaimSetCommandV53ServiceTests.cs
@@ -23,7 +23,7 @@ using EdFi.Ods.AdminApp.Management.Api.Automapper;
 namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 {
     [TestFixture]
-    public class DeleteResourceOnClaimSetCommandTests : SecurityData53TestBase
+    public class DeleteResourceOnClaimSetCommandV53ServiceTests : SecurityData53TestBase
     {
         private IMapper _mapper;
 
@@ -63,7 +63,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             Scoped<ISecurityContext>(securityContext =>
             {
-                var command = new DeleteResourceOnClaimSetCommand(securityContext);
+                var command = new DeleteResourceOnClaimSetCommandV53Service(securityContext);
                 command.Execute(deleteResourceOnClaimSetModel);
             });
 
@@ -110,7 +110,7 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 
             Scoped<ISecurityContext>(securityContext =>
             {
-                var command = new DeleteResourceOnClaimSetCommand(securityContext);
+                var command = new DeleteResourceOnClaimSetCommandV53Service(securityContext);
                 command.Execute(deleteResourceOnClaimSetModel);
             });
 

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/DeleteResourceOnClaimSetCommandV6ServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/DeleteResourceOnClaimSetCommandV6ServiceTests.cs
@@ -1,0 +1,187 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
+using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets;
+using EdFi.Security.DataAccess.Contexts;
+using Shouldly;
+using AutoMapper;
+using Moq;
+using static EdFi.Ods.AdminApp.Management.Tests.Testing;
+using static EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets.DeleteClaimSetResourceModel;
+
+using Application = EdFi.Security.DataAccess.Models.Application;
+using ClaimSet = EdFi.Security.DataAccess.Models.ClaimSet;
+using ResourceClaim = EdFi.Security.DataAccess.Models.ResourceClaim;
+using EdFi.Ods.AdminApp.Management.Api.Automapper;
+
+namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
+{
+    [TestFixture]
+    public class DeleteResourceOnClaimSetCommandV6ServiceTests : SecurityDataTestBase
+    {
+        private IMapper _mapper;
+
+        [SetUp]
+        public void Init()
+        {
+            var config = new MapperConfiguration(cfg => cfg.AddProfile<AdminManagementMappingProfile>());
+            _mapper = config.CreateMapper();
+        }
+
+        [Test]
+        public void ShouldDeleteParentResourceOnClaimSet()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var testClaimSet = new ClaimSet { ClaimSetName = "TestClaimSet", Application = testApplication };
+            Save(testClaimSet);
+
+            var parentIds = UniqueNameList("ParentRc", 1);
+            var testResources = SetupParentResourceClaimsWithChildren(testClaimSet, testApplication, parentIds, UniqueNameList("ChildRc", 1));
+
+            var parentResourcesOnClaimSetOriginalCount =
+                testResources.Count(x => x.ResourceClaim.ParentResourceClaim == null);
+
+            var testResourceToDelete = testResources.Select(x => x.ResourceClaim).Single(x => x.ResourceName == parentIds.First());
+
+            var deleteResourceOnClaimSetModel = new DeleteClaimSetResourceModel
+            {
+                ClaimSetId = testClaimSet.ClaimSetId,
+                ResourceClaimId = testResourceToDelete.ResourceClaimId,
+                ClaimSetName = testClaimSet.ClaimSetName,
+                ResourceName = testResourceToDelete.ResourceName
+            };
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new DeleteResourceOnClaimSetCommandV6Service(securityContext);
+                command.Execute(deleteResourceOnClaimSetModel);
+            });
+
+            Transaction(securityContext =>
+            {
+                var resourceClaimsForClaimSet =
+                    securityContext.ClaimSetResourceClaimActions.Where(x => x.ClaimSet.ClaimSetId == testClaimSet.ClaimSetId && x.ResourceClaim.ParentResourceClaimId == null);
+                resourceClaimsForClaimSet.Count().ShouldBe(parentResourcesOnClaimSetOriginalCount - 1);
+
+                var resultResourceClaim = resourceClaimsForClaimSet.SingleOrDefault(x => x.ResourceClaim.ResourceClaimId == testResourceToDelete.ResourceClaimId);
+
+                resultResourceClaim.ShouldBeNull();
+            });
+        }
+
+        [Test]
+        public void ShouldDeleteChildResourceOnClaimSet()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var testClaimSet = new ClaimSet { ClaimSetName = "TestClaimSet", Application = testApplication };
+            Save(testClaimSet);
+
+            var parentRcNames = UniqueNameList("ParentRc", 1);
+            var childRcNames = UniqueNameList("ChildRc", 1);
+            var testResources = SetupParentResourceClaimsWithChildren(testClaimSet, testApplication, parentRcNames, childRcNames);
+
+            var childRcNameToTest = $"{childRcNames.First()}-{parentRcNames.First()}";
+            var parentResourcesOnClaimSetOriginalCount =
+                testResources.Count(x => x.ResourceClaim.ParentResourceClaim == null);
+
+            var testParentResource = testResources.Select(x => x.ResourceClaim).Single(x => x.ResourceName == parentRcNames.First());
+            var childResourcesForParentOriginalCount = testResources.Count(x => x.ResourceClaim.ParentResourceClaimId == testParentResource.ResourceClaimId);
+            var testChildResourceToDelete = testResources.Select(x => x.ResourceClaim).Single(x => x.ResourceName == childRcNameToTest && x.ParentResourceClaimId == testParentResource.ResourceClaimId);
+
+            var deleteResourceOnClaimSetModel = new DeleteClaimSetResourceModel
+            {
+                ClaimSetId = testClaimSet.ClaimSetId,
+                ResourceClaimId = testChildResourceToDelete.ResourceClaimId,
+                ClaimSetName = testClaimSet.ClaimSetName,
+                ResourceName = testChildResourceToDelete.ResourceName
+            };
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new DeleteResourceOnClaimSetCommandV6Service(securityContext);
+                command.Execute(deleteResourceOnClaimSetModel);
+            });
+
+            List<Management.ClaimSetEditor.ResourceClaim> resourceClaimsForClaimSet = null;
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var getResourcesByClaimSetIdQuery = new GetResourcesByClaimSetIdQuery(new StubOdsSecurityModelVersionResolver.V6(),
+                    null, new GetResourcesByClaimSetIdQueryV6Service(securityContext, _mapper));
+                resourceClaimsForClaimSet = getResourcesByClaimSetIdQuery.AllResources(testClaimSet.ClaimSetId).ToList();
+            });
+            resourceClaimsForClaimSet.Count.ShouldBe(parentResourcesOnClaimSetOriginalCount);
+
+            Transaction(securityContext =>
+            {
+                var resultChildResources =
+                    securityContext.ClaimSetResourceClaimActions.Where(x => x.ClaimSet.ClaimSetId == testClaimSet.ClaimSetId && x.ResourceClaim.ParentResourceClaimId == testParentResource.ResourceClaimId);
+                resultChildResources.Count().ShouldBe(childResourcesForParentOriginalCount - 1);
+
+                var resultResourceClaim = resultChildResources.SingleOrDefault(x => x.ResourceClaim.ResourceClaimId == testChildResourceToDelete.ResourceClaimId);
+
+                resultResourceClaim.ShouldBeNull();
+            });
+        }
+
+        [Test]
+        public void ShouldNotDeleteIfResourceNotOnClaimSet()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var testClaimSet = new ClaimSet { ClaimSetName = "TestClaimSet", Application = testApplication };
+            Save(testClaimSet);
+
+            var testResources = SetupParentResourceClaimsWithChildren(testClaimSet, testApplication, UniqueNameList("ParentRc", 3), UniqueNameList("ChildRc", 1));
+
+            var resourceNotOnClaimSet = new ResourceClaim
+            {
+                Application = testApplication,
+                ClaimName = "TestClaim99",
+                DisplayName = "TestResource99",
+                ParentResourceClaim = null,
+                ResourceName = "TestResource99"
+            };
+            Save(resourceNotOnClaimSet);
+
+            var deleteResourceOnClaimSetModel = new DeleteClaimSetResourceModel
+            {
+                ClaimSetId = testClaimSet.ClaimSetId,
+                ResourceClaimId = resourceNotOnClaimSet.ResourceClaimId,
+                ClaimSetName = testClaimSet.ClaimSetName,
+                ResourceName = resourceNotOnClaimSet.ResourceName
+            };
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var getResourcesByClaimSetIdQuery = new GetResourcesByClaimSetIdQuery(new StubOdsSecurityModelVersionResolver.V6(),
+                    null, new GetResourcesByClaimSetIdQueryV6Service(securityContext, _mapper));
+
+                var validator = new DeleteClaimSetResourceModelValidator(getResourcesByClaimSetIdQuery);
+                var validationResults = validator.Validate(deleteResourceOnClaimSetModel);
+                validationResults.IsValid.ShouldBe(false);
+                validationResults.Errors.Single().ErrorMessage.ShouldBe("This resource does not exist on the claimset.");
+            });
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditResourceOnClaimSetCommandV53ServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/EditResourceOnClaimSetCommandV53ServiceTests.cs
@@ -1,0 +1,345 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using NUnit.Framework;
+using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
+using EdFi.Ods.AdminApp.Web.Models.ViewModels.ClaimSets;
+using EdFi.SecurityCompatiblity53.DataAccess.Contexts;
+using Shouldly;
+using Moq;
+
+using static EdFi.Ods.AdminApp.Management.Tests.Testing;
+
+using Application = EdFi.SecurityCompatiblity53.DataAccess.Models.Application;
+using ClaimSet = EdFi.SecurityCompatiblity53.DataAccess.Models.ClaimSet;
+using ResourceClaim = EdFi.Ods.AdminApp.Management.ClaimSetEditor.ResourceClaim;
+using AutoMapper;
+using EdFi.Ods.AdminApp.Management.Api.Automapper;
+
+namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
+{
+    [TestFixture]
+    public class EditResourceOnClaimSetCommandV53ServiceTests : SecurityData53TestBase
+    {
+        private IMapper _mapper;
+
+        [SetUp]
+        public void Init()
+        {
+            var config = new MapperConfiguration(cfg => cfg.AddProfile<AdminManagementMappingProfile>());
+            _mapper = config.CreateMapper();
+        }
+
+        [Test]
+        public void ShouldEditParentResourcesOnClaimSet()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var testClaimSet = new ClaimSet { ClaimSetName = "TestClaimSet", Application = testApplication };
+            Save(testClaimSet);
+
+            var testResources = SetupParentResourceClaimsWithChildren(testClaimSet, testApplication);
+
+            var testResource1ToEdit = testResources.Select(x => x.ResourceClaim).Single(x => x.ResourceName == "TestParentResourceClaim1");
+            var testResource2ToNotEdit = testResources.Select(x => x.ResourceClaim).Single(x => x.ResourceName == "TestParentResourceClaim2");
+
+            var editedResource = new ResourceClaim
+            {
+                Id = testResource1ToEdit.ResourceClaimId,
+                Name = testResource1ToEdit.ResourceName,
+                Create = false,
+                Read = false,
+                Update = true,
+                Delete = true
+            };
+
+            var editResourceOnClaimSetModel = new Mock<IEditResourceOnClaimSetModel>();
+            editResourceOnClaimSetModel.Setup(x => x.ClaimSetId).Returns(testClaimSet.ClaimSetId);
+            editResourceOnClaimSetModel.Setup(x => x.ResourceClaim).Returns(editedResource);
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new EditResourceOnClaimSetCommandV53Service(securityContext);
+                command.Execute(editResourceOnClaimSetModel.Object);
+            });
+
+            var resourceClaimsForClaimSet = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
+
+            var parentResources = testResources.Where(x =>
+                x.ClaimSet.ClaimSetId == testClaimSet.ClaimSetId && x.ResourceClaim.ParentResourceClaim == null).Select(x => x.ResourceClaim).ToList();
+            resourceClaimsForClaimSet.Count().ShouldBe(parentResources.Count);
+
+            var resultResourceClaim1 = resourceClaimsForClaimSet.Single(x => x.Id == editedResource.Id);
+
+            resultResourceClaim1.Create.ShouldBe(editedResource.Create);
+            resultResourceClaim1.Read.ShouldBe(editedResource.Read);
+            resultResourceClaim1.Update.ShouldBe(editedResource.Update);
+            resultResourceClaim1.Delete.ShouldBe(editedResource.Delete);
+
+            var resultResourceClaim2 = resourceClaimsForClaimSet.Single(x => x.Id == testResource2ToNotEdit.ResourceClaimId);
+
+            resultResourceClaim2.Create.ShouldBe(true);
+            resultResourceClaim2.Read.ShouldBe(false);
+            resultResourceClaim2.Update.ShouldBe(false);
+            resultResourceClaim2.Delete.ShouldBe(false);
+        }
+
+        [Test]
+        public void ShouldEditChildResourcesOnClaimSet()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var testClaimSet = new ClaimSet { ClaimSetName = "TestClaimSet", Application = testApplication };
+            Save(testClaimSet);
+
+            var testResources = SetupParentResourceClaimsWithChildren(testClaimSet, testApplication);
+
+            var testParentResource = testResources.Single(x => x.ResourceClaim.ResourceName == "TestParentResourceClaim1");
+
+            var testChildResource1ToEdit = Transaction(securityContext => securityContext.ResourceClaims.Single(x => x.ResourceName == "TestChildResourceClaim1" && x.ParentResourceClaimId == testParentResource.ResourceClaim.ResourceClaimId));
+            var testChildResource2NotToEdit = Transaction(securityContext => securityContext.ResourceClaims.Single(x => x.ResourceName == "TestChildResourceClaim2" && x.ParentResourceClaimId == testParentResource.ResourceClaim.ResourceClaimId));
+
+            var editedResource = new ResourceClaim
+            {
+                Id = testChildResource1ToEdit.ResourceClaimId,
+                Name = testChildResource1ToEdit.ResourceName,
+                Create = false,
+                Read = false,
+                Update = true,
+                Delete = true
+            };
+
+            var editResourceOnClaimSetModel = new Mock<IEditResourceOnClaimSetModel>();
+            editResourceOnClaimSetModel.Setup(x => x.ClaimSetId).Returns(testClaimSet.ClaimSetId);
+            editResourceOnClaimSetModel.Setup(x => x.ResourceClaim).Returns(editedResource);
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new EditResourceOnClaimSetCommandV53Service(securityContext);
+                command.Execute(editResourceOnClaimSetModel.Object);
+            });
+
+            var resourceClaimsForClaimSet = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
+
+            var parentResources = testResources.Where(x =>
+                x.ClaimSet.ClaimSetId == testClaimSet.ClaimSetId && x.ResourceClaim.ParentResourceClaim == null).Select(x => x.ResourceClaim).ToList();
+            resourceClaimsForClaimSet.Count.ShouldBe(parentResources.Count);
+
+            var resultParentResourceClaim = resourceClaimsForClaimSet.Single(x => x.Id == testParentResource.ResourceClaim.ResourceClaimId);
+            resultParentResourceClaim.Create.ShouldBe(true);
+            resultParentResourceClaim.Read.ShouldBe(false);
+            resultParentResourceClaim.Update.ShouldBe(false);
+            resultParentResourceClaim.Delete.ShouldBe(false);
+
+            var resultChildResourceClaim1 =
+                resultParentResourceClaim.Children.Single(x => x.Id == editedResource.Id);
+
+            resultChildResourceClaim1.Create.ShouldBe(editedResource.Create);
+            resultChildResourceClaim1.Read.ShouldBe(editedResource.Read);
+            resultChildResourceClaim1.Update.ShouldBe(editedResource.Update);
+            resultChildResourceClaim1.Delete.ShouldBe(editedResource.Delete);
+
+            var resultChildResourceClaim2 =
+                resultParentResourceClaim.Children.Single(x => x.Id == testChildResource2NotToEdit.ResourceClaimId);
+
+            resultChildResourceClaim2.Create.ShouldBe(true);
+            resultChildResourceClaim2.Read.ShouldBe(false);
+            resultChildResourceClaim2.Update.ShouldBe(false);
+            resultChildResourceClaim2.Delete.ShouldBe(false);
+        }
+
+        [Test]
+        public void ShouldNotAddInvalidResourcesToClaimSetDuringEdit()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var testClaimSet = new ClaimSet { ClaimSetName = "TestClaimSet", Application = testApplication };
+            Save(testClaimSet);
+
+            var testResources = SetupParentResourceClaimsWithChildren(testClaimSet, testApplication);
+
+            var testResource = testResources.Single(x => x.ResourceClaim.ResourceName == "TestParentResourceClaim1").ResourceClaim;
+
+            var invalidResource = new ResourceClaim
+            {
+                Id = testResource.ResourceClaimId,
+                Name = testResource.ResourceName,
+                Create = false,
+                Read = false,
+                Update = false,
+                Delete = false
+            };
+
+            var editResourceOnClaimSetModel = new EditClaimSetResourceModel
+            {
+                ClaimSetId = testClaimSet.ClaimSetId,
+                ResourceClaim = invalidResource,
+                ExistingResourceClaims = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId)
+            };
+
+            var validator = new EditClaimSetResourceModelValidator();
+            var validationResults = validator.Validate(editResourceOnClaimSetModel);
+            validationResults.IsValid.ShouldBe(false);
+            validationResults.Errors.Single().ErrorMessage.ShouldBe("Only valid resources can be added. A resource must have at least one action associated with it to be added. The following is an invalid resource:\nTestParentResourceClaim1");
+        }
+
+        [Test]
+        public void ShouldNotAddDuplicateResourcesToClaimSetDuringEdit()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var testClaimSet = new ClaimSet { ClaimSetName = "TestClaimSet", Application = testApplication };
+            Save(testClaimSet);
+
+            SetupParentResourceClaimsWithChildren(testClaimSet, testApplication);
+
+            var existingResources = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
+
+            var duplicateResource = existingResources.Single(x => x.Name == "TestParentResourceClaim1");
+
+            var editResourceOnClaimSetModel = new EditClaimSetResourceModel
+            {
+                ClaimSetId = testClaimSet.ClaimSetId,
+                ResourceClaim = duplicateResource,
+                ExistingResourceClaims = existingResources
+            };
+
+            var validator = new EditClaimSetResourceModelValidator();
+            var validationResults = validator.Validate(editResourceOnClaimSetModel);
+            validationResults.IsValid.ShouldBe(false);
+            validationResults.Errors.Single().ErrorMessage.ShouldBe("Only unique resource claims can be added. The following is a duplicate resource:\nTestParentResourceClaim1");
+        }
+
+        [Test]
+        public void ShouldAddParentResourceToClaimSet()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var testClaimSet = new ClaimSet { ClaimSetName = "TestClaimSet", Application = testApplication };
+            Save(testClaimSet);
+
+            var testResources = SetupResourceClaims(testApplication);
+            var testResourceToAdd = testResources.Single(x => x.ResourceName == "TestParentResourceClaim1");
+            var resourceToAdd = new ResourceClaim()
+            {
+                Id = testResourceToAdd.ResourceClaimId,
+                Name = testResourceToAdd.ResourceName,
+                Create = true,
+                Read = false,
+                Update = true,
+                Delete = false
+            };
+            var existingResources = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
+
+            var editResourceOnClaimSetModel = new EditClaimSetResourceModel
+            {
+                ClaimSetId = testClaimSet.ClaimSetId,
+                ResourceClaim = resourceToAdd,
+                ExistingResourceClaims = existingResources
+            };
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new EditResourceOnClaimSetCommandV53Service(securityContext);
+                command.Execute(editResourceOnClaimSetModel);
+            });
+
+            var resourceClaimsForClaimSet = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
+
+            var resultResourceClaim1 = resourceClaimsForClaimSet.Single(x => x.Name == testResourceToAdd.ResourceName);
+
+            resultResourceClaim1.Create.ShouldBe(resourceToAdd.Create);
+            resultResourceClaim1.Read.ShouldBe(resourceToAdd.Read);
+            resultResourceClaim1.Update.ShouldBe(resourceToAdd.Update);
+            resultResourceClaim1.Delete.ShouldBe(resourceToAdd.Delete);
+        }
+
+        [Test]
+        public void ShouldAddChildResourcesToClaimSet()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var testClaimSet = new ClaimSet { ClaimSetName = "TestClaimSet", Application = testApplication };
+            Save(testClaimSet);
+
+            var testResources = SetupResourceClaims(testApplication);
+            var testParentResource1 = testResources.Single(x => x.ResourceName == "TestParentResourceClaim1");
+
+            var testChildResource1ToAdd = Transaction(securityContext => securityContext.ResourceClaims.Single(x => x.ResourceName == "TestChildResourceClaim1" && x.ParentResourceClaimId == testParentResource1.ResourceClaimId));
+            var resourceToAdd = new ResourceClaim()
+            {
+                    Id = testChildResource1ToAdd.ResourceClaimId,
+                    Name = testChildResource1ToAdd.ResourceName,
+                    Create = true,
+                    Read = false,
+                    Update = true,
+                    Delete = false
+            };
+            var existingResources = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
+
+            var editResourceOnClaimSetModel = new EditClaimSetResourceModel
+            {
+                ClaimSetId = testClaimSet.ClaimSetId,
+                ResourceClaim = resourceToAdd,
+                ExistingResourceClaims = existingResources
+            };
+
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var command = new EditResourceOnClaimSetCommandV53Service(securityContext);
+                command.Execute(editResourceOnClaimSetModel);
+            });
+
+            var resourceClaimsForClaimSet = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
+
+            var resultChildResourceClaim1 =
+                resourceClaimsForClaimSet.Single(x => x.Name == testChildResource1ToAdd.ResourceName);
+
+            resultChildResourceClaim1.Create.ShouldBe(resourceToAdd.Create);
+            resultChildResourceClaim1.Read.ShouldBe(resourceToAdd.Read);
+            resultChildResourceClaim1.Update.ShouldBe(resourceToAdd.Update);
+            resultChildResourceClaim1.Delete.ShouldBe(resourceToAdd.Delete);
+        }
+
+        private List<ResourceClaim> ResourceClaimsForClaimSet(int securityContextClaimSetId)
+        {
+            List<ResourceClaim> list = null;
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var getResourcesByClaimSetIdQuery = new GetResourcesByClaimSetIdQuery(new StubOdsSecurityModelVersionResolver.V3_5(),
+                    new GetResourcesByClaimSetIdQueryV53Service(securityContext, _mapper), null);
+                list = getResourcesByClaimSetIdQuery.AllResources(securityContextClaimSetId).ToList();
+            });
+            return list;
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/UpdateResourcesOnClaimSetCommandV53ServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/UpdateResourcesOnClaimSetCommandV53ServiceTests.cs
@@ -1,0 +1,125 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System;
+using System.Linq;
+using NUnit.Framework;
+using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
+using Shouldly;
+using EdFi.SecurityCompatiblity53.DataAccess.Contexts;
+using System.Collections.Generic;
+using Moq;
+
+using static EdFi.Ods.AdminApp.Management.Tests.Testing;
+
+using Application = EdFi.SecurityCompatiblity53.DataAccess.Models.Application;
+using ClaimSet = EdFi.SecurityCompatiblity53.DataAccess.Models.ClaimSet;
+using AutoMapper;
+using EdFi.Ods.AdminApp.Management.Api.Automapper;
+
+namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
+{
+    [TestFixture]
+    public class UpdateResourcesOnClaimSetCommandV53ServiceTests : SecurityData53TestBase
+    {
+        private IMapper _mapper;
+
+        [SetUp]
+        public void Init()
+        {
+            var config = new MapperConfiguration(cfg => cfg.AddProfile<AdminManagementMappingProfile>());
+            _mapper = config.CreateMapper();
+        }
+
+        [Test]
+        public void ShouldUpdateResourcesOnClaimSet()
+        {
+            var testApplication = new Application
+            {
+                ApplicationName = $"Test Application {DateTime.Now:O}"
+            };
+            Save(testApplication);
+
+            var testClaimSet = new ClaimSet { ClaimSetName = "TestClaimSet", Application = testApplication };
+            Save(testClaimSet);
+
+            var testResources = SetupParentResourceClaimsWithChildren(testClaimSet, testApplication, 2, 1);
+
+            var testParentResource = testResources.Single(x => x.ResourceClaim.ResourceName == "TestParentResourceClaim1");
+            var secondTestParentResource = testResources.Single(x => x.ResourceClaim.ResourceName == "TestParentResourceClaim2");
+
+            var testChildResource1ToEdit = Transaction(securityContext => securityContext.ResourceClaims.Single(x => x.ResourceName == "TestChildResourceClaim1" && x.ParentResourceClaimId == testParentResource.ResourceClaim.ResourceClaimId));
+
+            var addedResourceClaimsForClaimSet = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
+            addedResourceClaimsForClaimSet.Count().ShouldBe(2);
+            var secondParentResourceClaim = addedResourceClaimsForClaimSet.Single(x => x.Id == secondTestParentResource.ResourceClaim.ResourceClaimId);
+            secondParentResourceClaim.ShouldNotBeNull();
+
+            var updatedParent1 = new ResourceClaim
+            {
+                Id = testParentResource.ResourceClaim.ResourceClaimId,
+                Name = testParentResource.ResourceClaim.ResourceName,
+                Create = false,
+                Read = false,
+                Update = true,
+                Delete = true,
+                Children = new List<ResourceClaim> {new ResourceClaim
+                    {
+                        Id = testChildResource1ToEdit.ResourceClaimId,
+                        Name = testChildResource1ToEdit.ResourceName,
+                        Create = false,
+                        Read = false,
+                        Update = true,
+                        Delete = true
+                    } }
+            };
+
+            var updatedResourceClaims = new List<ResourceClaim>
+            {
+                updatedParent1
+            };
+
+            var updateResourcesOnClaimSetModel = new Mock<IUpdateResourcesOnClaimSetModel>();
+            updateResourcesOnClaimSetModel.Setup(x => x.ClaimSetId).Returns(testClaimSet.ClaimSetId);
+            updateResourcesOnClaimSetModel.Setup(x => x.ResourceClaims).Returns(updatedResourceClaims);
+
+            Scoped<Security.DataAccess.Contexts.ISecurityContext>(securityContextLatest =>
+            {
+                Scoped<ISecurityContext>(
+                    securityContext53 =>
+                    {
+                        var addOrEditResourcesOnClaimSetCommand = new AddOrEditResourcesOnClaimSetCommand(
+                            new EditResourceOnClaimSetCommand(new StubOdsSecurityModelVersionResolver.V3_5(),
+                            new EditResourceOnClaimSetCommandV53Service(securityContext53), null),
+                            new Management.Database.Queries.GetResourceClaimsQuery(securityContextLatest),
+                            new OverrideDefaultAuthorizationStrategyCommand(
+                                new StubOdsSecurityModelVersionResolver.V3_5(),
+                                new OverrideDefaultAuthorizationStrategyV53Service(securityContext53), null));
+
+                        var command = new UpdateResourcesOnClaimSetCommandV53Service(securityContext53, addOrEditResourcesOnClaimSetCommand);
+                        command.Execute(updateResourcesOnClaimSetModel.Object);
+                    });
+            });
+
+            var resourceClaimsForClaimSet = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
+            resourceClaimsForClaimSet.Count.ShouldBe(1);
+            resourceClaimsForClaimSet.First().Name.ShouldBe(testParentResource.ResourceClaim.ResourceName);
+            resourceClaimsForClaimSet.First().Children.Count.ShouldBe(1);
+            resourceClaimsForClaimSet.First().Children.First().Name.ShouldBe(testChildResource1ToEdit.ResourceName);
+        }
+
+        private List<ResourceClaim> ResourceClaimsForClaimSet(int securityContextClaimSetId)
+        {
+            List<ResourceClaim> list = null;
+            Scoped<ISecurityContext>(securityContext =>
+            {
+                var getResourcesByClaimSetIdQuery = new GetResourcesByClaimSetIdQuery(new StubOdsSecurityModelVersionResolver.V3_5(),
+                    new GetResourcesByClaimSetIdQueryV53Service(securityContext, _mapper), null);
+                list = getResourcesByClaimSetIdQuery.AllResources(securityContextClaimSetId).ToList();
+            });
+            return list;
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/UpdateResourcesOnClaimSetCommandV6ServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/UpdateResourcesOnClaimSetCommandV6ServiceTests.cs
@@ -91,23 +91,20 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             updateResourcesOnClaimSetModel.Setup(x => x.ClaimSetId).Returns(testClaimSet.ClaimSetId);
             updateResourcesOnClaimSetModel.Setup(x => x.ResourceClaims).Returns(updatedResourceClaims);
 
-            Scoped<ISecurityContext>(securityContextLatest =>
-            {
-                Scoped<ISecurityContext>(
-                    securityContext6 =>
-                    {
-                        var addOrEditResourcesOnClaimSetCommand = new AddOrEditResourcesOnClaimSetCommand(
-                            new EditResourceOnClaimSetCommand(new StubOdsSecurityModelVersionResolver.V6(),
-                            null, new EditResourceOnClaimSetCommandV6Service(securityContext6)),
-                            new Management.Database.Queries.GetResourceClaimsQuery(securityContextLatest),
-                            new OverrideDefaultAuthorizationStrategyCommand(
-                                new StubOdsSecurityModelVersionResolver.V6(), null,
-                                new OverrideDefaultAuthorizationStrategyV6Service(securityContext6)));
+            Scoped<ISecurityContext>(
+                securityContext6 =>
+                {
+                    var addOrEditResourcesOnClaimSetCommand = new AddOrEditResourcesOnClaimSetCommand(
+                        new EditResourceOnClaimSetCommand(new StubOdsSecurityModelVersionResolver.V6(),
+                        null, new EditResourceOnClaimSetCommandV6Service(securityContext6)),
+                        new Management.Database.Queries.GetResourceClaimsQuery(securityContext6),
+                        new OverrideDefaultAuthorizationStrategyCommand(
+                            new StubOdsSecurityModelVersionResolver.V6(), null,
+                            new OverrideDefaultAuthorizationStrategyV6Service(securityContext6)));
 
-                        var command = new UpdateResourcesOnClaimSetCommandV6Service(securityContext6, addOrEditResourcesOnClaimSetCommand);
-                        command.Execute(updateResourcesOnClaimSetModel.Object);
-                    });
-            });
+                    var command = new UpdateResourcesOnClaimSetCommandV6Service(securityContext6, addOrEditResourcesOnClaimSetCommand);
+                    command.Execute(updateResourcesOnClaimSetModel.Object);
+                });
 
             var resourceClaimsForClaimSet = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
             resourceClaimsForClaimSet.Count.ShouldBe(1);

--- a/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/UpdateResourcesOnClaimSetCommandV6ServiceTests.cs
+++ b/Application/EdFi.Ods.AdminApp.Management.Tests/ClaimSetEditor/UpdateResourcesOnClaimSetCommandV6ServiceTests.cs
@@ -8,21 +8,21 @@ using System.Linq;
 using NUnit.Framework;
 using EdFi.Ods.AdminApp.Management.ClaimSetEditor;
 using Shouldly;
-using EdFi.SecurityCompatiblity53.DataAccess.Contexts;
+using EdFi.Security.DataAccess.Contexts;
 using System.Collections.Generic;
 using Moq;
 
 using static EdFi.Ods.AdminApp.Management.Tests.Testing;
 
-using Application = EdFi.SecurityCompatiblity53.DataAccess.Models.Application;
-using ClaimSet = EdFi.SecurityCompatiblity53.DataAccess.Models.ClaimSet;
+using Application = EdFi.Security.DataAccess.Models.Application;
+using ClaimSet = EdFi.Security.DataAccess.Models.ClaimSet;
 using AutoMapper;
 using EdFi.Ods.AdminApp.Management.Api.Automapper;
 
 namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
 {
     [TestFixture]
-    public class UpdateResourcesOnClaimSetCommandTests : SecurityData53TestBase
+    public class UpdateResourcesOnClaimSetCommandV6ServiceTests : SecurityDataTestBase
     {
         private IMapper _mapper;
 
@@ -45,12 +45,18 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             var testClaimSet = new ClaimSet { ClaimSetName = "TestClaimSet", Application = testApplication };
             Save(testClaimSet);
 
-            var testResources = SetupParentResourceClaimsWithChildren(testClaimSet, testApplication, 2, 1);
+            var parentRcNames = UniqueNameList("ParentRc", 2);
+            var childName = "ChildRc098";
+            var testResources = SetupParentResourceClaimsWithChildren(testClaimSet, testApplication, parentRcNames,
+                new List<string>{ childName });
 
-            var testParentResource = testResources.Single(x => x.ResourceClaim.ResourceName == "TestParentResourceClaim1");
-            var secondTestParentResource = testResources.Single(x => x.ResourceClaim.ResourceName == "TestParentResourceClaim2");
+            var testParentResource = testResources.Single(x => x.ResourceClaim.ResourceName == parentRcNames.First());
+            var secondTestParentResource = testResources.Single(x => x.ResourceClaim.ResourceName == parentRcNames.Last());
 
-            var testChildResource1ToEdit = Transaction(securityContext => securityContext.ResourceClaims.Single(x => x.ResourceName == "TestChildResourceClaim1" && x.ParentResourceClaimId == testParentResource.ResourceClaim.ResourceClaimId));
+            var firstParentChildName = $"{childName}-{parentRcNames.First()}";
+
+            var testChildResource1ToEdit = Transaction(securityContext =>
+            securityContext.ResourceClaims.Single(x => x.ResourceName == firstParentChildName && x.ParentResourceClaimId == testParentResource.ResourceClaim.ResourceClaimId));
 
             var addedResourceClaimsForClaimSet = ResourceClaimsForClaimSet(testClaimSet.ClaimSetId);
             addedResourceClaimsForClaimSet.Count().ShouldBe(2);
@@ -76,28 +82,29 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
                     } }
             };
 
-            var updatedResourceClaims = new List<ResourceClaim>();
-            updatedResourceClaims.Add(updatedParent1);
+            var updatedResourceClaims = new List<ResourceClaim>
+            {
+                updatedParent1
+            };
 
             var updateResourcesOnClaimSetModel = new Mock<IUpdateResourcesOnClaimSetModel>();
             updateResourcesOnClaimSetModel.Setup(x => x.ClaimSetId).Returns(testClaimSet.ClaimSetId);
             updateResourcesOnClaimSetModel.Setup(x => x.ResourceClaims).Returns(updatedResourceClaims);
 
-            Scoped<EdFi.Security.DataAccess.Contexts.ISecurityContext>(securityContextLatest =>
+            Scoped<ISecurityContext>(securityContextLatest =>
             {
                 Scoped<ISecurityContext>(
-                    securityContext53 =>
+                    securityContext6 =>
                     {
                         var addOrEditResourcesOnClaimSetCommand = new AddOrEditResourcesOnClaimSetCommand(
-                            new EditResourceOnClaimSetCommand(securityContext53),
+                            new EditResourceOnClaimSetCommand(new StubOdsSecurityModelVersionResolver.V6(),
+                            null, new EditResourceOnClaimSetCommandV6Service(securityContext6)),
                             new Management.Database.Queries.GetResourceClaimsQuery(securityContextLatest),
                             new OverrideDefaultAuthorizationStrategyCommand(
-                                new StubOdsSecurityModelVersionResolver.V3_5(),
-                                new OverrideDefaultAuthorizationStrategyV53Service(securityContext53), null));
+                                new StubOdsSecurityModelVersionResolver.V6(), null,
+                                new OverrideDefaultAuthorizationStrategyV6Service(securityContext6)));
 
-                        var command = new UpdateResourcesOnClaimSetCommand(
-                            securityContext53, addOrEditResourcesOnClaimSetCommand);
-
+                        var command = new UpdateResourcesOnClaimSetCommandV6Service(securityContext6, addOrEditResourcesOnClaimSetCommand);
                         command.Execute(updateResourcesOnClaimSetModel.Object);
                     });
             });
@@ -114,8 +121,8 @@ namespace EdFi.Ods.AdminApp.Management.Tests.ClaimSetEditor
             List<ResourceClaim> list = null;
             Scoped<ISecurityContext>(securityContext =>
             {
-                var getResourcesByClaimSetIdQuery = new GetResourcesByClaimSetIdQuery(new StubOdsSecurityModelVersionResolver.V3_5(),
-                    new GetResourcesByClaimSetIdQueryV53Service(securityContext, _mapper), null);
+                var getResourcesByClaimSetIdQuery = new GetResourcesByClaimSetIdQuery(new StubOdsSecurityModelVersionResolver.V6(),
+                    null, new GetResourcesByClaimSetIdQueryV6Service(securityContext, _mapper));
                 list = getResourcesByClaimSetIdQuery.AllResources(securityContextClaimSetId).ToList();
             });
             return list;

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/DeleteResourceOnClaimSetCommandV53Service.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/DeleteResourceOnClaimSetCommandV53Service.cs
@@ -1,0 +1,29 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Linq;
+using EdFi.SecurityCompatiblity53.DataAccess.Contexts;
+
+namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
+{
+    public class DeleteResourceOnClaimSetCommandV53Service
+    {
+        private readonly ISecurityContext _context;
+
+        public DeleteResourceOnClaimSetCommandV53Service(ISecurityContext context)
+        {
+            _context = context;
+        }
+
+        public void Execute(IDeleteResourceOnClaimSetModel model)
+        {
+            var resourceClaimsToRemove = _context.ClaimSetResourceClaims.Where(x =>
+                x.ResourceClaim.ResourceClaimId == model.ResourceClaimId && x.ClaimSet.ClaimSetId == model.ClaimSetId).ToList();
+
+            _context.ClaimSetResourceClaims.RemoveRange(resourceClaimsToRemove);
+            _context.SaveChanges();
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/DeleteResourceOnClaimSetCommandV6Service.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/DeleteResourceOnClaimSetCommandV6Service.cs
@@ -1,0 +1,37 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Linq;
+using EdFi.Security.DataAccess.Contexts;
+
+namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
+{
+    public class DeleteResourceOnClaimSetCommandV6Service
+    {
+        private readonly ISecurityContext _context;
+
+        public DeleteResourceOnClaimSetCommandV6Service(ISecurityContext context)
+        {
+            _context = context;
+        }
+
+        public void Execute(IDeleteResourceOnClaimSetModel model)
+        {
+            var resourceClaimsToRemove = _context.ClaimSetResourceClaimActions.Where(x =>
+                x.ResourceClaim.ResourceClaimId == model.ResourceClaimId && x.ClaimSet.ClaimSetId == model.ClaimSetId).ToList();
+
+            foreach (var resourceClaimAction in resourceClaimsToRemove)
+            {
+                var resourceClaimActionAuthorizationStrategyOverrides = _context.ClaimSetResourceClaimActionAuthorizationStrategyOverrides.
+                    Where(x => x.ClaimSetResourceClaimActionId == resourceClaimAction.ClaimSetResourceClaimActionId);
+
+                _context.ClaimSetResourceClaimActionAuthorizationStrategyOverrides.RemoveRange(resourceClaimActionAuthorizationStrategyOverrides);
+            }
+
+            _context.ClaimSetResourceClaimActions.RemoveRange(resourceClaimsToRemove);
+            _context.SaveChanges();
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/EditResourceOnClaimSetCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/EditResourceOnClaimSetCommand.cs
@@ -3,127 +3,32 @@
 // The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
 // See the LICENSE and NOTICES files in the project root for more information.
 
-using System.Collections.Generic;
-using System.Data.Entity;
-using System.Linq;
-using EdFi.SecurityCompatiblity53.DataAccess.Contexts;
-using EdFi.SecurityCompatiblity53.DataAccess.Models;
-
-using SecurityClaimSet = EdFi.SecurityCompatiblity53.DataAccess.Models.ClaimSet;
-
 namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
 {
     public class EditResourceOnClaimSetCommand
     {
-        private readonly ISecurityContext _context;
+        private readonly IOdsSecurityModelVersionResolver _resolver;
+        private readonly EditResourceOnClaimSetCommandV53Service _v53Service;
+        private readonly EditResourceOnClaimSetCommandV6Service _v6Service;
 
-        public EditResourceOnClaimSetCommand(ISecurityContext context)
+        public EditResourceOnClaimSetCommand(IOdsSecurityModelVersionResolver resolver,
+            EditResourceOnClaimSetCommandV53Service v53Service,
+            EditResourceOnClaimSetCommandV6Service v6Service)
         {
-            _context = context;
+            _resolver = resolver;
+            _v53Service = v53Service;
+            _v6Service = v6Service;
         }
-
+        
         public void Execute(IEditResourceOnClaimSetModel model)
         {
-            var resourceClaimToEdit = model.ResourceClaim;
-
-            var claimSetToEdit = _context.ClaimSets.Single(x => x.ClaimSetId == model.ClaimSetId);
-
-            var claimSetResourceClaimsToEdit = _context.ClaimSetResourceClaims
-                .Include(x => x.ResourceClaim)
-                .Include(x => x.Action)
-                .Include(x => x.ClaimSet)
-                .Where(x => x.ResourceClaim.ResourceClaimId == resourceClaimToEdit.Id && x.ClaimSet.ClaimSetId == claimSetToEdit.ClaimSetId)
-                .ToList();
-
-            AddEnabledActionsToClaimSet(resourceClaimToEdit, claimSetResourceClaimsToEdit, claimSetToEdit);
-
-            RemoveDisabledActionsFromClaimSet(resourceClaimToEdit, claimSetResourceClaimsToEdit);
-
-            _context.SaveChanges();
-        }
-
-        private void RemoveDisabledActionsFromClaimSet(ResourceClaim modelResourceClaim, IEnumerable<ClaimSetResourceClaim> resourceClaimsToEdit)
-        {
-            var recordsToRemove = new List<ClaimSetResourceClaim>();
-
-            foreach (var claimSetResourceClaim in resourceClaimsToEdit)
-            {
-                if (claimSetResourceClaim.Action.ActionName == Action.Create.Value && !modelResourceClaim.Create)
-                {
-                    recordsToRemove.Add(claimSetResourceClaim);
-                }
-                else if (claimSetResourceClaim.Action.ActionName == Action.Read.Value && !modelResourceClaim.Read)
-                {
-                    recordsToRemove.Add(claimSetResourceClaim);
-                }
-                else if (claimSetResourceClaim.Action.ActionName == Action.Update.Value && !modelResourceClaim.Update)
-                {
-                    recordsToRemove.Add(claimSetResourceClaim);
-                }
-                else if (claimSetResourceClaim.Action.ActionName == Action.Delete.Value && !modelResourceClaim.Delete)
-                {
-                    recordsToRemove.Add(claimSetResourceClaim);
-                }
-            }
-
-            if (recordsToRemove.Any())
-            {
-                _context.ClaimSetResourceClaims.RemoveRange(recordsToRemove);
-            }
-        }
-
-        private void AddEnabledActionsToClaimSet(ResourceClaim modelResourceClaim, IReadOnlyCollection<ClaimSetResourceClaim> claimSetResourceClaimsToEdit, SecurityClaimSet claimSetToEdit)
-        {
-            var actionsFromDb = _context.Actions.ToList();
-
-            var resourceClaimFromDb = _context.ResourceClaims.Single(x => x.ResourceClaimId == modelResourceClaim.Id);
-
-            var recordsToAdd = new List<ClaimSetResourceClaim>();
-
-            if (modelResourceClaim.Create && claimSetResourceClaimsToEdit.All(x => x.Action.ActionName != Action.Create.Value))
-            {
-                recordsToAdd.Add(new ClaimSetResourceClaim
-                {
-                    Action = actionsFromDb.Single(x => x.ActionName == Action.Create.Value),
-                    ClaimSet = claimSetToEdit,
-                    ResourceClaim = resourceClaimFromDb
-                });
-            }
-
-            if (modelResourceClaim.Read && claimSetResourceClaimsToEdit.All(x => x.Action.ActionName != Action.Read.Value))
-            {
-                recordsToAdd.Add(new ClaimSetResourceClaim
-                {
-                    Action = actionsFromDb.Single(x => x.ActionName == Action.Read.Value),
-                    ClaimSet = claimSetToEdit,
-                    ResourceClaim = resourceClaimFromDb
-                });
-            }
-
-            if (modelResourceClaim.Update && claimSetResourceClaimsToEdit.All(x => x.Action.ActionName != Action.Update.Value))
-            {
-                recordsToAdd.Add(new ClaimSetResourceClaim
-                {
-                    Action = actionsFromDb.Single(x => x.ActionName == Action.Update.Value),
-                    ClaimSet = claimSetToEdit,
-                    ResourceClaim = resourceClaimFromDb
-                });
-            }
-
-            if (modelResourceClaim.Delete && claimSetResourceClaimsToEdit.All(x => x.Action.ActionName != Action.Delete.Value))
-            {
-                recordsToAdd.Add(new ClaimSetResourceClaim
-                {
-                    Action = actionsFromDb.Single(x => x.ActionName == Action.Delete.Value),
-                    ClaimSet = claimSetToEdit,
-                    ResourceClaim = resourceClaimFromDb
-                });
-            }
-
-            if (recordsToAdd.Any())
-            {
-                _context.ClaimSetResourceClaims.AddRange(recordsToAdd);
-            }
+            var securityModel = _resolver.DetermineSecurityModel();
+            if (securityModel == EdFiOdsSecurityModelCompatibility.ThreeThroughFive)
+                _v53Service.Execute(model);
+            else if (securityModel == EdFiOdsSecurityModelCompatibility.Six)
+                _v6Service.Execute(model);
+            else
+                throw new EdFiOdsSecurityModelCompatibilityException(securityModel);
         }
     }
 

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/EditResourceOnClaimSetCommandV53Service.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/EditResourceOnClaimSetCommandV53Service.cs
@@ -1,0 +1,129 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using EdFi.SecurityCompatiblity53.DataAccess.Contexts;
+using EdFi.SecurityCompatiblity53.DataAccess.Models;
+
+using SecurityClaimSet = EdFi.SecurityCompatiblity53.DataAccess.Models.ClaimSet;
+
+namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
+{
+    public class EditResourceOnClaimSetCommandV53Service
+    {
+        private readonly ISecurityContext _context;
+
+        public EditResourceOnClaimSetCommandV53Service(ISecurityContext context)
+        {
+            _context = context;
+        }
+
+        public void Execute(IEditResourceOnClaimSetModel model)
+        {
+            var resourceClaimToEdit = model.ResourceClaim;
+
+            var claimSetToEdit = _context.ClaimSets.Single(x => x.ClaimSetId == model.ClaimSetId);
+
+            var claimSetResourceClaimsToEdit = _context.ClaimSetResourceClaims
+                .Include(x => x.ResourceClaim)
+                .Include(x => x.Action)
+                .Include(x => x.ClaimSet)
+                .Where(x => x.ResourceClaim.ResourceClaimId == resourceClaimToEdit.Id && x.ClaimSet.ClaimSetId == claimSetToEdit.ClaimSetId)
+                .ToList();
+
+            AddEnabledActionsToClaimSet(resourceClaimToEdit, claimSetResourceClaimsToEdit, claimSetToEdit);
+
+            RemoveDisabledActionsFromClaimSet(resourceClaimToEdit, claimSetResourceClaimsToEdit);
+
+            _context.SaveChanges();
+        }
+
+        private void RemoveDisabledActionsFromClaimSet(ResourceClaim modelResourceClaim, IEnumerable<ClaimSetResourceClaim> resourceClaimsToEdit)
+        {
+            var recordsToRemove = new List<ClaimSetResourceClaim>();
+
+            foreach (var claimSetResourceClaim in resourceClaimsToEdit)
+            {
+                if (claimSetResourceClaim.Action.ActionName == Action.Create.Value && !modelResourceClaim.Create)
+                {
+                    recordsToRemove.Add(claimSetResourceClaim);
+                }
+                else if (claimSetResourceClaim.Action.ActionName == Action.Read.Value && !modelResourceClaim.Read)
+                {
+                    recordsToRemove.Add(claimSetResourceClaim);
+                }
+                else if (claimSetResourceClaim.Action.ActionName == Action.Update.Value && !modelResourceClaim.Update)
+                {
+                    recordsToRemove.Add(claimSetResourceClaim);
+                }
+                else if (claimSetResourceClaim.Action.ActionName == Action.Delete.Value && !modelResourceClaim.Delete)
+                {
+                    recordsToRemove.Add(claimSetResourceClaim);
+                }
+            }
+
+            if (recordsToRemove.Any())
+            {
+                _context.ClaimSetResourceClaims.RemoveRange(recordsToRemove);
+            }
+        }
+
+        private void AddEnabledActionsToClaimSet(ResourceClaim modelResourceClaim, IReadOnlyCollection<ClaimSetResourceClaim> claimSetResourceClaimsToEdit, SecurityClaimSet claimSetToEdit)
+        {
+            var actionsFromDb = _context.Actions.ToList();
+
+            var resourceClaimFromDb = _context.ResourceClaims.Single(x => x.ResourceClaimId == modelResourceClaim.Id);
+
+            var recordsToAdd = new List<ClaimSetResourceClaim>();
+
+            if (modelResourceClaim.Create && claimSetResourceClaimsToEdit.All(x => x.Action.ActionName != Action.Create.Value))
+            {
+                recordsToAdd.Add(new ClaimSetResourceClaim
+                {
+                    Action = actionsFromDb.Single(x => x.ActionName == Action.Create.Value),
+                    ClaimSet = claimSetToEdit,
+                    ResourceClaim = resourceClaimFromDb
+                });
+            }
+
+            if (modelResourceClaim.Read && claimSetResourceClaimsToEdit.All(x => x.Action.ActionName != Action.Read.Value))
+            {
+                recordsToAdd.Add(new ClaimSetResourceClaim
+                {
+                    Action = actionsFromDb.Single(x => x.ActionName == Action.Read.Value),
+                    ClaimSet = claimSetToEdit,
+                    ResourceClaim = resourceClaimFromDb
+                });
+            }
+
+            if (modelResourceClaim.Update && claimSetResourceClaimsToEdit.All(x => x.Action.ActionName != Action.Update.Value))
+            {
+                recordsToAdd.Add(new ClaimSetResourceClaim
+                {
+                    Action = actionsFromDb.Single(x => x.ActionName == Action.Update.Value),
+                    ClaimSet = claimSetToEdit,
+                    ResourceClaim = resourceClaimFromDb
+                });
+            }
+
+            if (modelResourceClaim.Delete && claimSetResourceClaimsToEdit.All(x => x.Action.ActionName != Action.Delete.Value))
+            {
+                recordsToAdd.Add(new ClaimSetResourceClaim
+                {
+                    Action = actionsFromDb.Single(x => x.ActionName == Action.Delete.Value),
+                    ClaimSet = claimSetToEdit,
+                    ResourceClaim = resourceClaimFromDb
+                });
+            }
+
+            if (recordsToAdd.Any())
+            {
+                _context.ClaimSetResourceClaims.AddRange(recordsToAdd);
+            }
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/EditResourceOnClaimSetCommandV6Service.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/EditResourceOnClaimSetCommandV6Service.cs
@@ -1,0 +1,127 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Collections.Generic;
+using System.Data.Entity;
+using System.Linq;
+using EdFi.Security.DataAccess.Contexts;
+using EdFi.Security.DataAccess.Models;
+
+namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
+{
+    public class EditResourceOnClaimSetCommandV6Service
+    {
+        private readonly ISecurityContext _context;
+
+        public EditResourceOnClaimSetCommandV6Service(ISecurityContext context)
+        {
+            _context = context;
+        }
+
+        public void Execute(IEditResourceOnClaimSetModel model)
+        {
+            var resourceClaimToEdit = model.ResourceClaim;
+
+            var claimSetToEdit = _context.ClaimSets.Single(x => x.ClaimSetId == model.ClaimSetId);
+
+            var claimSetResourceClaimsToEdit = _context.ClaimSetResourceClaimActions
+                .Include(x => x.ResourceClaim)
+                .Include(x => x.Action)
+                .Include(x => x.ClaimSet)
+                .Where(x => x.ResourceClaim.ResourceClaimId == resourceClaimToEdit.Id && x.ClaimSet.ClaimSetId == claimSetToEdit.ClaimSetId)
+                .ToList();
+
+            AddEnabledActionsToClaimSet(resourceClaimToEdit, claimSetResourceClaimsToEdit, claimSetToEdit);
+
+            RemoveDisabledActionsFromClaimSet(resourceClaimToEdit, claimSetResourceClaimsToEdit);
+
+            _context.SaveChanges();
+        }
+
+        private void RemoveDisabledActionsFromClaimSet(ResourceClaim modelResourceClaim, IEnumerable<ClaimSetResourceClaimAction> resourceClaimsToEdit)
+        {
+            var recordsToRemove = new List<ClaimSetResourceClaimAction>();
+
+            foreach (var claimSetResourceClaim in resourceClaimsToEdit)
+            {
+                if (claimSetResourceClaim.Action.ActionName == Action.Create.Value && !modelResourceClaim.Create)
+                {
+                    recordsToRemove.Add(claimSetResourceClaim);
+                }
+                else if (claimSetResourceClaim.Action.ActionName == Action.Read.Value && !modelResourceClaim.Read)
+                {
+                    recordsToRemove.Add(claimSetResourceClaim);
+                }
+                else if (claimSetResourceClaim.Action.ActionName == Action.Update.Value && !modelResourceClaim.Update)
+                {
+                    recordsToRemove.Add(claimSetResourceClaim);
+                }
+                else if (claimSetResourceClaim.Action.ActionName == Action.Delete.Value && !modelResourceClaim.Delete)
+                {
+                    recordsToRemove.Add(claimSetResourceClaim);
+                }
+            }
+
+            if (recordsToRemove.Any())
+            {
+                _context.ClaimSetResourceClaimActions.RemoveRange(recordsToRemove);
+            }
+        }
+
+        private void AddEnabledActionsToClaimSet(ResourceClaim modelResourceClaim, IReadOnlyCollection<ClaimSetResourceClaimAction> claimSetResourceClaimsToEdit, Security.DataAccess.Models.ClaimSet claimSetToEdit)
+        {
+            var actionsFromDb = _context.Actions.ToList();
+
+            var resourceClaimFromDb = _context.ResourceClaims.Single(x => x.ResourceClaimId == modelResourceClaim.Id);
+
+            var recordsToAdd = new List<ClaimSetResourceClaimAction>();
+
+            if (modelResourceClaim.Create && claimSetResourceClaimsToEdit.All(x => x.Action.ActionName != Action.Create.Value))
+            {
+                recordsToAdd.Add(new ClaimSetResourceClaimAction
+                {
+                    Action = actionsFromDb.Single(x => x.ActionName == Action.Create.Value),
+                    ClaimSet = claimSetToEdit,
+                    ResourceClaim = resourceClaimFromDb
+                });
+            }
+
+            if (modelResourceClaim.Read && claimSetResourceClaimsToEdit.All(x => x.Action.ActionName != Action.Read.Value))
+            {
+                recordsToAdd.Add(new ClaimSetResourceClaimAction
+                {
+                    Action = actionsFromDb.Single(x => x.ActionName == Action.Read.Value),
+                    ClaimSet = claimSetToEdit,
+                    ResourceClaim = resourceClaimFromDb
+                });
+            }
+
+            if (modelResourceClaim.Update && claimSetResourceClaimsToEdit.All(x => x.Action.ActionName != Action.Update.Value))
+            {
+                recordsToAdd.Add(new ClaimSetResourceClaimAction
+                {
+                    Action = actionsFromDb.Single(x => x.ActionName == Action.Update.Value),
+                    ClaimSet = claimSetToEdit,
+                    ResourceClaim = resourceClaimFromDb
+                });
+            }
+
+            if (modelResourceClaim.Delete && claimSetResourceClaimsToEdit.All(x => x.Action.ActionName != Action.Delete.Value))
+            {
+                recordsToAdd.Add(new ClaimSetResourceClaimAction
+                {
+                    Action = actionsFromDb.Single(x => x.ActionName == Action.Delete.Value),
+                    ClaimSet = claimSetToEdit,
+                    ResourceClaim = resourceClaimFromDb
+                });
+            }
+
+            if (recordsToAdd.Any())
+            {
+                _context.ClaimSetResourceClaimActions.AddRange(recordsToAdd);
+            }
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/UpdateResourcesOnClaimSetCommand.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/UpdateResourcesOnClaimSetCommand.cs
@@ -4,31 +4,33 @@
 // See the LICENSE and NOTICES files in the project root for more information.
 
 using System.Collections.Generic;
-using System.Linq;
-using EdFi.SecurityCompatiblity53.DataAccess.Contexts;
-
 
 namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
 {
     public class UpdateResourcesOnClaimSetCommand
     {
-        private readonly ISecurityContext _context;
-        private readonly AddOrEditResourcesOnClaimSetCommand _addOrEditResourcesOnClaimSetCommand;
+        private readonly IOdsSecurityModelVersionResolver _resolver;
+        private readonly UpdateResourcesOnClaimSetCommandV53Service _v53Service;
+        private readonly UpdateResourcesOnClaimSetCommandV6Service _v6Service;
 
-        public UpdateResourcesOnClaimSetCommand(ISecurityContext context, AddOrEditResourcesOnClaimSetCommand addOrEditResourcesOnClaimSetCommand)
+        public UpdateResourcesOnClaimSetCommand(IOdsSecurityModelVersionResolver resolver,
+            UpdateResourcesOnClaimSetCommandV53Service v53Service,
+            UpdateResourcesOnClaimSetCommandV6Service v6Service)
         {
-            _context = context;
-            _addOrEditResourcesOnClaimSetCommand = addOrEditResourcesOnClaimSetCommand;
+            _resolver = resolver;
+            _v53Service = v53Service;
+            _v6Service = v6Service;
         }
 
         public void Execute(IUpdateResourcesOnClaimSetModel model)
         {
-            var resourceClaimsForClaimSet =
-                _context.ClaimSetResourceClaims.Where(x => x.ClaimSet.ClaimSetId == model.ClaimSetId).ToList();
-            _context.ClaimSetResourceClaims.RemoveRange(resourceClaimsForClaimSet);
-            _context.SaveChanges();
-
-            _addOrEditResourcesOnClaimSetCommand.Execute(model.ClaimSetId, model.ResourceClaims);
+            var securityModel = _resolver.DetermineSecurityModel();
+            if (securityModel == EdFiOdsSecurityModelCompatibility.ThreeThroughFive)
+                _v53Service.Execute(model);
+            else if (securityModel == EdFiOdsSecurityModelCompatibility.Six)
+                _v6Service.Execute(model);
+            else
+                throw new EdFiOdsSecurityModelCompatibilityException(securityModel);
         }
     }
 

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/UpdateResourcesOnClaimSetCommandV53Service.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/UpdateResourcesOnClaimSetCommandV53Service.cs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Linq;
+using EdFi.SecurityCompatiblity53.DataAccess.Contexts;
+
+namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
+{
+    public class UpdateResourcesOnClaimSetCommandV53Service
+    {
+        private readonly ISecurityContext _context;
+        private readonly AddOrEditResourcesOnClaimSetCommand _addOrEditResourcesOnClaimSetCommand;
+
+        public UpdateResourcesOnClaimSetCommandV53Service(ISecurityContext context,
+            AddOrEditResourcesOnClaimSetCommand addOrEditResourcesOnClaimSetCommand)
+        {
+            _context = context;
+            _addOrEditResourcesOnClaimSetCommand = addOrEditResourcesOnClaimSetCommand;
+        }
+
+        public void Execute(IUpdateResourcesOnClaimSetModel model)
+        {
+            var resourceClaimsForClaimSet =
+                _context.ClaimSetResourceClaims.Where(x => x.ClaimSet.ClaimSetId == model.ClaimSetId).ToList();
+            _context.ClaimSetResourceClaims.RemoveRange(resourceClaimsForClaimSet);
+            _context.SaveChanges();
+
+            _addOrEditResourcesOnClaimSetCommand.Execute(model.ClaimSetId, model.ResourceClaims);
+        }
+    }
+}

--- a/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/UpdateResourcesOnClaimSetCommandV6Service.cs
+++ b/Application/EdFi.Ods.AdminApp.Management/ClaimSetEditor/UpdateResourcesOnClaimSetCommandV6Service.cs
@@ -1,0 +1,33 @@
+// SPDX-License-Identifier: Apache-2.0
+// Licensed to the Ed-Fi Alliance under one or more agreements.
+// The Ed-Fi Alliance licenses this file to you under the Apache License, Version 2.0.
+// See the LICENSE and NOTICES files in the project root for more information.
+
+using System.Linq;
+using EdFi.Security.DataAccess.Contexts;
+
+namespace EdFi.Ods.AdminApp.Management.ClaimSetEditor
+{
+    public class UpdateResourcesOnClaimSetCommandV6Service
+    {
+        private readonly ISecurityContext _context;
+        private readonly AddOrEditResourcesOnClaimSetCommand _addOrEditResourcesOnClaimSetCommand;
+
+        public UpdateResourcesOnClaimSetCommandV6Service(ISecurityContext context,
+            AddOrEditResourcesOnClaimSetCommand addOrEditResourcesOnClaimSetCommand)
+        {
+            _context = context;
+            _addOrEditResourcesOnClaimSetCommand = addOrEditResourcesOnClaimSetCommand;
+        }
+
+        public void Execute(IUpdateResourcesOnClaimSetModel model)
+        {
+            var resourceClaimsForClaimSet =
+                _context.ClaimSetResourceClaimActions.Where(x => x.ClaimSet.ClaimSetId == model.ClaimSetId).ToList();
+            _context.ClaimSetResourceClaimActions.RemoveRange(resourceClaimsForClaimSet);
+            _context.SaveChanges();
+
+            _addOrEditResourcesOnClaimSetCommand.Execute(model.ClaimSetId, model.ResourceClaims);
+        }
+    }
+}


### PR DESCRIPTION
@jasonh-edfi 
Please help review and merge the changes.
Did not fix the "ClaimSetFileImportCommandTests" - tests have dependencies over the classes which are not updated to support multiversion (ex: AddClaimSetCommand) yet. Will be updating as part of https://tracker.ed-fi.org/browse/ADMINAPI-69 ticket.
Thanks 