### PR TITLE
[ADMINAPI-981] Clean up release promote step

### DIFF
--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -72,5 +72,5 @@ jobs:
             Password    = (ConvertTo-SecureString -String "${{ env.ARTIFACTS_API_KEY }}" -AsPlainText -Force)
           }
 
-          Import-Module ./eng/promote-packages.ps1
+          Import-Module ./eng/promote-packages.psm1
           Invoke-Promote @arguments

--- a/.github/workflows/on-release.yml
+++ b/.github/workflows/on-release.yml
@@ -72,4 +72,5 @@ jobs:
             Password    = (ConvertTo-SecureString -String "${{ env.ARTIFACTS_API_KEY }}" -AsPlainText -Force)
           }
 
-          ./eng/promote-packages.ps1 @arguments
+          Import-Module ./eng/promote-packages.ps1
+          Invoke-Promote @arguments


### PR DESCRIPTION
Clean up the release promotion step. We no longer need to look at the ref. Make process consistent with `Edfi.Installer.AppCommon`